### PR TITLE
DOC Update references for how to update documentation (4 branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Silverstripe Developer Documentation
+
+The developer documentation ina modified Markdown format, as published on [docs.silverstripe.org](https://docs.silverstripe.org) ([source](https://github.com/silverstripe/doc.silverstripe.org)).
+
+## License
+
+[Creative Commons Attribution 3.0 New Zealand](https://creativecommons.org/licenses/by/3.0/nz/)

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "silverstripe/developer-docs",
+    "description": "Developer documentation for the Silverstripe framework and CMS. Added to packagist for release purposes.",
+    "homepage": "https://silverstripe.org",
+    "license": "CC-BY-3.0",
+    "keywords": [
+        "silverstripe",
+        "framework",
+        "cms",
+        "developer",
+        "documentation"
+    ],
+    "authors": [
+        {
+            "name": "SilverStripe",
+            "homepage": "http://silverstripe.com"
+        },
+        {
+            "name": "The SilverStripe Community",
+            "homepage": "http://silverstripe.org"
+        }
+    ]
+}

--- a/en/05_Contributing/00_Issues_and_Bugs.md
+++ b/en/05_Contributing/00_Issues_and_Bugs.md
@@ -20,7 +20,7 @@ Before submitting a bug:
  * Is this a security issue? Please follow our separate reporting guidelines below.
  * Which modules does this issue belong to? Each one has its own issue tracker.
    If you are unsure, [create an issue](https://github.com/silverstripe/silverstripe-framework/issues/new) on the the "framework" repository.
-   Note that [documentation issues](https://github.com/silverstripe/silverstripe-framework/issues) are tracked in "framework" as well. 
+ * Note that [documentation issues](https://github.com/silverstripe/developer-docs/issues) are tracked in the "developer-docs" repository.
  * Try to reproduce your issue on a [clean installation](/getting_started/composer#using-development-versions), maybe the bug has already been fixed on an unreleased branch?
  * The bugtracker is not the place to discuss enhancements, please use 
    the ["feature ideas" forum category](https://forum.silverstripe.org/c/feature-ideas) and our [community channels](https://www.silverstripe.org/community).

--- a/en/05_Contributing/06_Documentation.md
+++ b/en/05_Contributing/06_Documentation.md
@@ -11,46 +11,47 @@ Documentation for a software project is a continuing, collaborative effort. We e
 Modifying documentation requires basic knowledge of [PHPDoc](http://en.wikipedia.org/wiki/PHPDoc) and 
 [Markdown](http://daringfireball.net/projects/markdown/) as well as a GitHub user account.
 
+[info]
+Note that there are two sources of documentation, depending on the intended audience. You can see where each of those lives in the [repositories](#repositories) section below.
+[/info]
+
 ## Editing online
 
-The easiest way of editing any documentation is by clicking the "Edit this page" button at the bottom of the 
-page you want to edit. Alternatively, locate the appropriate .md file in the 
-[github.com/silverstripe/silverstripe-framework](https://github.com/silverstripe/silverstripe-framework/tree/master/docs/) repository and press the "edit" button. **You will need a free GitHub account to do this**. 
+The easiest way of editing any documentation is by clicking the "Edit on GitHub" button at the bottom of the
+page you want to edit. Alternatively, locate the appropriate .md file in the
+[silverstripe/developer-docs](https://github.com/silverstripe/developer-docs/) repository and press the "edit" button. **You will need a free GitHub account to do this**.
 
 
  * After editing the documentation, describe your changes in the "commit summary" and "extended description" fields below then press "Commit Changes".
  * After committing you changes, you will see a form to submit a Pull Request: "[pull requests](http://help.github.com/pull-requests/)". You should be able to adjust the version to which your documentation changes apply before submitting the form. Any changes submitted in a pull request will be sent to the core committers for approval.
 
 [warning]
-You should make your changes in the lowest branch they apply to. For instance, if you fix a spelling issue that you found in the 3.2 documentation, submit your fix to that branch in Github and it'll be copied to the master (4.0) version of the documentation automatically. *Don't submit multiple pull requests*.
+You should make your changes in the lowest major branch they apply to. For instance, if you fix a spelling issue that you found in the CMS 3 documentation, submit your fix to the `3` branch in Github and it'll be copied to the most recent major version of the documentation automatically. *Don't submit multiple pull requests for the same change*.
 [/warning]
 
 ## Editing on your computer
 
 If you prefer to edit content on your local machine, you can "[fork](http://help.github.com/forking/)" the 
-[github.com/silverstripe/silverstripe-framework](http://github.com/silverstripe/silverstripe-framework) and 
-[github.com/silverstripe/silverstripe-cms](http://github.com/silverstripe/silverstripe-cms) repositories, make changes locally, and then send us a "[pull request](http://help.github.com/pull-requests/)" to incorporate your changes. If you have previously downloaded SilverStripe or a module, chances are that you already have these repositories on your machine.
-
-The documentation is kept alongside the source code in the `docs/` subfolder of any SilverStripe module, framework or CMS folder.
+[silverstripe/developer-docs](http://github.com/silverstripe/developer-docs) repository, make changes locally, and then [send us a pull request](http://help.github.com/pull-requests/) to incorporate your changes.
 
 [warning]
-If you submit a new feature or an API change, we strongly recommend that your patch includes updates to the necessary documentation. This helps prevent our documentation from getting out of date.
+If you submit a new feature or an API change, we strongly recommend and request that you include a PR to update the necessary documentation. This helps prevent our documentation from getting out of date.
 [/warning]
 
 ## Repositories
 
-*  End-user help: [userhelp.silverstripe.org](http://github.com/silverstripe/userhelp.silverstripe.org)
-*  Developer guides: [docs.silverstripe.org](http://github.com/silverstripe/doc.silverstripe.org)
-*  Developer API documentation: [api.silverstripe.org](http://github.com/silverstripe/api.silverstripe.org)
+* End-user help: [silverstripe/silverstripe-userhelp-content](https://github.com/silverstripe/silverstripe-userhelp-content/)
+* Developer guides: [silverstripe/developer-docs](http://github.com/silverstripe/developer-docs/)
+* Website code for user and developer docs: [silverstripe/doc.silverstripe.org](https://github.com/silverstripe/doc.silverstripe.org)
+* Developer API documentation: [silverstripe/api.silverstripe.org](http://github.com/silverstripe/api.silverstripe.org)
 
 ## Source control
 
-In order to balance editorial control with effective collaboration, we keep documentation alongside the module source code, e.g. in `framework/docs/`, or as code comments within PHP code. Contributing documentation is the same process as providing any other patch (see [Contributing code](code)).
+Contributing documentation is the same process as providing any other patch (see [Contributing code](code)).
 
-Documentation should always be provided for the earliest stable release it applies to
-(we're merging up these changes to newer versions periodically).
-One exception are docs in `docs/en/contributing/`, which should always be changed on `master` since 
-its contents are general advice and don't apply to any particular release.  
+If you are fixing incorrect or incomplete information for the current major version, you should create a PR that targets the branch for the latest stable release (e.g. `4.11`).
+
+If you are adding documentation for functionality that has not yet been released, you should target the most recent _major_ branch (e.g. `4`)
 
 ## What to write
 


### PR DESCRIPTION
Also add composer.json and readme.

composer.json is needed so that cow can install the docs and use them to get commits for the changelog and to commit the changelog.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10215