### PR TITLE
MNT Add action for building docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: Build Docs
+on:
+  push:
+    branches:
+      - '3'
+      - '4.11'
+    paths:
+      - 'en/**'
+jobs:
+  build:
+    name: build-docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run build hook
+        run: curl -X POST -d {} https://api.netlify.com/build_hooks/${{ secrets.NETLIFY_BUILD_HOOK }}
+


### PR DESCRIPTION
Add the action for building docs, copied over from framework.
I haven't pulled the history for the action like I did for docs, but you can see that history [here](https://github.com/silverstripe/silverstripe-framework/commits/4/.github/workflows/main.yml) if you're in the future and are curious.

## DEPENDENCY
This PR must not be merged before https://github.com/silverstripe/doc.silverstripe.org/pull/243

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10215