### PR TITLE
Update adding_middleware.md

### DIFF
--- a/en/02_Developer_Guides/19_GraphQL/06_extending/adding_middleware.md
+++ b/en/02_Developer_Guides/19_GraphQL/06_extending/adding_middleware.md
@@ -69,7 +69,7 @@ class LoggingMiddleware implements QueryMiddleware
             ));
         
         // Hand off execution to the next middleware
-        return $next($params);
+        return $next($schema, $query, $context, $vars);
     }
 }
 ```


### PR DESCRIPTION
When adding GraphQL query middleware, the `callMiddleware` function in the `QueryHandler` class expects four entries when returning `$next`.  Thanks.