### PR TITLE
DOC Update doc for moving files.

### DIFF
--- a/en/02_Developer_Guides/14_Files/01_File_Management.md
+++ b/en/02_Developer_Guides/14_Files/01_File_Management.md
@@ -142,11 +142,11 @@ SilverStripe\Assets\File:
     psd: 'Adobe Photoshop File'
 ```
 
-## Modifying files
+## Renaming and moving files
 
 In order to move or rename a file you can simply update the `Name` property, or assign the `ParentID` to a new
 folder. Please note that these modifications are made simply on the draft stage, and will not be copied
-to live until a publish is made (either on this object, or cascading from a parent).
+to live until a publish is made via the CMS (either on this object, or cascading from a parent).
 
 When files are renamed using the ORM, all file variants are automatically renamed at the same time.
 
@@ -159,6 +159,25 @@ if ($file) {
   // to 'newname.jpg' and 'newname__variant.jpg' respectively
   $file->Name = 'newname.jpg';
   $file->write();
+}
+```
+
+Note that you can cause the file to be moved immediately by [setting the Versioned reading mode](api:SilverStripe\Versioned\Versioned::set_reading_mode()) to draft temporarily.
+
+```php
+use SilverStripe\Assets\File;
+use SilverStripe\Versioned\Versioned;
+
+$file = File::get()->filter('Name', 'oldname.jpg')->first();
+if ($file) {
+  // The below will immediately move 'oldname.jpg' and 'oldname__variant.jpg'
+  // to 'newname.jpg' and 'newname__variant.jpg' respectively
+  $file->Name = 'newname.jpg';
+  Versioned::withVersionedMode(function() use ($file) {
+    Versioned::set_reading_mode('Stage.' . Versioned::DRAFT);
+    $file->write();
+    $file->publishSingle();
+  });
 }
 ```
 


### PR DESCRIPTION
The docs implied that you could just call `$file->publishSingle()` to propogate the change to live, but a check in `File::updateFilesystem()` explicitly blocks that from happening until the reading mode has changed:
https://github.com/silverstripe/silverstripe-assets/blob/4f5f62f22376db67f4af794337563f5c05e92acc/src/File.php#L811-L814

This PR updates the docs to show how to immediately move the file.