### PR TITLE
DOC Document removing deprecated support for PHPUnit 5.7

### DIFF
--- a/en/02_Developer_Guides/06_Testing/How_Tos/00_Write_a_SapphireTest.md
+++ b/en/02_Developer_Guides/06_Testing/How_Tos/00_Write_a_SapphireTest.md
@@ -106,7 +106,7 @@ The final part of our test is an assertion command, `assertEquals`. An assertion
 in our test methods (in this case we are testing if two values are equal). A test method can have more than one 
 assertion command, and if any one of these assertions fail, so will the test method.
 
-The example **phpunit.xml** file should be placed in the root folder of your project. PHPUnit 5.7 should be included by default, as a dev dependency, in the **composer.json** file.
+The example **phpunit.xml** file should be placed in the root folder of your project. PHPUnit 9 should be included by default, as a dev dependency, in the **composer.json** file.
 
 ## Caching
 

--- a/en/03_Upgrading/02_Upgrading_your_project.md
+++ b/en/03_Upgrading/02_Upgrading_your_project.md
@@ -15,6 +15,29 @@ summary: Upgrade your project to Silverstripe CMS 5.
   - If your composer.json file has its `extra.resources-dir` key set to `_resources`, you can remove that now.
   - If your composer.json file already does not have an `extra.resources-dir` key and you want to keep your resources in the `resources` directory, you can set `extra.resources-dir` to "resources".
   - If your composer.json file already does not have an `extra.resources-dir` key and you want to use the new default `_resources` directory, you may need to check that your code and templates don't assume the directory name for those resources. In your templates it is preferred to [use `$resourePath()` or `$resourceURL()`](developer_guides/templates/requirements/#direct-resource-urls) to get paths for resources.
+- Removed various API related to support for PHPUnit 5.7
+  - Removed deprecated method `SilverStripe\Core\BaseKernel::getIgnoredCIConfigs()`
+  - Removed deprecated method `SilverStripe\Core\Manifest\Module::getCIConfig()`
+  - Removed deprecated method `SilverStripe\Dev\TestKernel::getIgnoredCIConfigs()`
+  - Removed deprecated method `SilverStripe\Dev\TestKernel::setIgnoredCIConfigs()`
+  - Removed deprecated parameter `$ignoredCIConfigs` from `SilverStripe\Core\Manifest\ClassLoader::init()`
+  - Removed deprecated parameter `$ignoredCIConfigs` from `SilverStripe\Core\Manifest\ClassManifest::init()`
+  - Removed deprecated parameter `$ignoredCIConfigs` from `SilverStripe\Core\Manifest\ClassManifest::regenerate()`
+  - Removed deprecated parameter `$ignoredCIConfigs` from `SilverStripe\Core\Manifest\ModuleLoader::init()`
+  - Removed deprecated parameter `$ignoredCIConfigs` from `SilverStripe\Core\Manifest\ModuleManifest::init()`
+  - Removed deprecated parameter `$ignoredCIConfigs` from `SilverStripe\Core\Manifest\ModuleManifest::regenerate()`
+  - Removed deprecated parameter `$ignoredCIConfigs` from `SilverStripe\View\ThemeManifest::init()`
+  - Removed deprecated parameter `$ignoredCIConfigs` from `SilverStripe\View\ThemeManifest::regenerate()`
+  - Removed deprecated PHPUnit 5.7 version of the class `SilverStripe\Dev\Constraint\SSListContains`
+    - The PHPUnit 9 compatible version of this class remains.
+  - Removed deprecated PHPUnit 5.7 version of the class `SilverStripe\Dev\Constraint\SSListContainsOnlyMatchingItems`
+    - The PHPUnit 9 compatible version of this class remains.
+  - Removed deprecated PHPUnit 5.7 version of the class `SilverStripe\Dev\Constraint\ViewableDataContains`
+    - The PHPUnit 9 compatible version of this class remains.
+  - Removed deprecated PHPUnit 5.7 version of the class `SilverStripe\Dev\FunctionalTest`
+    - The PHPUnit 9 compatible version of this class remains.
+  - Removed deprecated PHPUnit 5.7 version of the class `SilverStripe\Dev\SapphireTest`
+    - The PHPUnit 9 compatible version of this class remains.
 
 ### silverstripe/vendor-plugin
 


### PR DESCRIPTION
This API is deprecated by https://github.com/silverstripe/silverstripe-framework/pull/10448 and removed by https://github.com/silverstripe/silverstripe-framework/pull/10444

The actual format of the upgrading docs can be sorted out closer to release - for now this serves as documentation of what breaking changes have been made.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10398