### PR TITLE
DOC Fix links from upgrade docs

### DIFF
--- a/en/04_Changelogs/5.0.0.md
+++ b/en/04_Changelogs/5.0.0.md
@@ -85,10 +85,10 @@ This is a major release and as a result there are a number of breaking API chang
 - `isDev` and `isTest` querystring arguments have been removed due to security concerns (see [ss-2018-005](https://www.silverstripe.org/download/security-releases/ss-2018-005/)).
 - The default value for the `RESOURCES_DIR` const has been changed to to "_resources"
   - The `Library::DEFAULT_RESOURCES_DIR` const in `silverstripe/vendor-plugin` has been changed to match.
-  - This can still be customised using `extra.resources-dir` in your composer.json file ([see relevant docs](developer_guides/templates/requirements/#configuring-your-project-exposed-folders))
+  - This can still be customised using `extra.resources-dir` in your composer.json file ([see relevant docs](/developer_guides/templates/requirements/#configuring-your-project-exposed-folders))
   - If your composer.json file has its `extra.resources-dir` key set to `_resources`, you can remove that now.
   - If your composer.json file already does not have an `extra.resources-dir` key and you want to keep your resources in the `resources` directory, you can set `extra.resources-dir` to "resources".
-  - If your composer.json file already does not have an `extra.resources-dir` key and you want to use the new default `_resources` directory, you may need to check that your code and templates don't assume the directory name for those resources. In your templates it is preferred to [use `$resourePath()` or `$resourceURL()`](developer_guides/templates/requirements/#direct-resource-urls) to get paths for resources.
+  - If your composer.json file already does not have an `extra.resources-dir` key and you want to use the new default `_resources` directory, you may need to check that your code and templates don't assume the directory name for those resources. In your templates it is preferred to [use `$resourePath()` or `$resourceURL()`](/developer_guides/templates/requirements/#direct-resource-urls) to get paths for resources.
 - `SilverStripe\Dev\FunctionalTest` is now abstract.
 - `SilverStripe\Dev\MigrationTask` is now abstract.
 - `SilverStripe\Dev\SapphireTest` is now abstract.


### PR DESCRIPTION
These links need a slash at the start so they're not relative to the upgrading section.