### PR TITLE
DOC Document changes in various rescued master commits

### DIFF
--- a/en/03_Upgrading/02_Upgrading_your_project.md
+++ b/en/03_Upgrading/02_Upgrading_your_project.md
@@ -7,9 +7,17 @@ summary: Upgrade your project to Silverstripe CMS 5.
 
 ## Breaking changes (by module, alphabetically)
 
+### dnadesign/silverstripe-elemental
+
+- Removed deprecated class `DNADesign\Elemental\Search\ElementalSolrIndex`.
+
+### silverstripe/cms
+
+- Removed deprecated class `SilverStripe\CMS\Controllers\CMSPageHistoryController` and the javascript associated with it.
+
 ### silverstripe/framework
 
-- Removed deprecated `ManifestFileFinder::RESOURCES_DIR`
+- Removed deprecated constant `ManifestFileFinder::RESOURCES_DIR`
 - Changed the default for the `RESOURCES_DIR` const to "_resources"
   - This can still be customised using `extra.resources-dir` in your composer.json file ([see relevant docs](developer_guides/templates/requirements/#configuring-your-project-exposed-folders))
   - If your composer.json file has its `extra.resources-dir` key set to `_resources`, you can remove that now.
@@ -38,8 +46,32 @@ summary: Upgrade your project to Silverstripe CMS 5.
     - The PHPUnit 9 compatible version of this class remains.
   - Removed deprecated PHPUnit 5.7 version of the class `SilverStripe\Dev\SapphireTest`
     - The PHPUnit 9 compatible version of this class remains.
+- Removed various API in ORM related to `Iterator`
+  - Removed `current()`, `key()`, `next()`, `nextRecord()`, `rewind()`, `seek()`, and `valid()` from the following classes:
+    - `SilverStripe\ORM\Connect\MySQLQuery`
+    - `SilverStripe\ORM\Connect\MySQLStatement`
+    - `SilverStripe\ORM\Connect\PDOQuery`
+    - `SilverStripe\ORM\Connect\Query`
+  - Removed `SilverStripe\ORM\DataList::getGenerator()` (use `getIterator()` instead)
+  - Removed the `SilverStripe\ORM\Map_Iterator` class. `SilverStripe\ORM\Map` now uses a generator instead.
+- Removed deprecated method `SilverStripe\Core\BaseKernel::sessionEnvironment()`
+- Removed deprecated method `SilverStripe\Core\Extensible::constructExtensions()`
+- `SilverStripe\Core\Extensible::invokeWithExtensions()` and `SilverStripe\Core\Extensible::extend()` now use the splat operator instead of having a concrete number of possible arguments.
+- `SilverStripe\Dev\FunctionalTest` is now abstract.
+- `SilverStripe\Dev\MigrationTask` is now abstract.
+- `SilverStripe\Dev\SapphireTest` is now abstract.
 
 ### silverstripe/vendor-plugin
 
 - Removed deprecated `Library::RESOURCES_DIR`
 - Changed `Library::DEFAULT_RESOURCES_DIR` to "_resources"
+
+### silverstripe/versioned
+
+- The constructor for `SilverStripe\Versioned\Versioned` now explicitly only accepts mode as a single argument.
+- Removed deprecated method `SilverStripe\Versioned\Versioned::doPublish()`
+- Removed deprecated method `SilverStripe\Versioned\Versioned::doRollbackTo()`
+- Removed deprecated method `SilverStripe\Versioned\Versioned::migrateVersion()`
+- Removed deprecated method `SilverStripe\Versioned\Versioned::onAfterRevertToLive()`
+- Removed deprecated method `SilverStripe\Versioned\Versioned::onAfterRollback()`
+- Removed deprecated method `SilverStripe\Versioned\Versioned::publish()`

--- a/en/04_Changelogs/5.0.0.md
+++ b/en/04_Changelogs/5.0.0.md
@@ -1,0 +1,51 @@
+---
+title: 5.0.0 (unreleased)
+---
+
+# 5.0.0 (unreleased)
+
+## Overview
+
+- [API changes](#api-changes)
+- [Features and enhancements](#features-and-enhancements)
+  - [Other features](#other-features)
+- [Bugfixes](#bugfixes)
+
+## API changes
+
+This is a major release and as a result there are a number of breaking API changes. For a full list of these see [upgrading your project](/upgrading/upgrading_your_project). Some specific details about a few of them are below.
+
+### General changes
+
+- `isDev` and `isTest` querystring arguments have been removed due to security concerns (see [ss-2018-005](https://www.silverstripe.org/download/security-releases/ss-2018-005/)).
+
+### ORM
+
+- Prior to 5.0.0, when using `SQLSelect::setFrom()` or `SQLSelect::create('*', $from)` to set table or subselect definitions,
+their aliases (applied by setting a string key for the array) were being ignored. This bug has been fixed - if you were working around this by manually setting the alias e.g. in a join, you can remove those workarounds now.
+- [Query](api:SilverStripe\ORM\Connect\Query) now implements `IteratorAggregate` instead of `Iterator`. This means `seek()` and other iterator methods are no longer available on this class and its subclasses. Use `getIterator()` instead.
+- [DataList](SilverStripe\ORM\DataList), its subclasses, [Map](api:SilverStripe\ORM\Map), and [ArrayList](SilverStripe\ORM\ArrayList) all now return generators from `getIterator()`. This reduces memory usage when looping over large result sets. As a result of this, `getGenerator()` has been removed as it is no longer needed. Note that `chunkedFetch()` has not been removed, as it may still be useful for very large result sets to fetch results in smaller chunks at a time.
+- For `DataObject` subclasses without a `table_name` defined, the default table name will now be shorter. This reduces the chance that the default table name will be too long for the database to handle - but best practice is still to explicitly declare `table_name` for all `DataObject` subclasses.
+  - If you have hardcoded references (e.g. in raw SQL queries) to table names for `DataObject` subclasses which are using a default table name, you may need to change those references. Best practice here is to use [DataObjectSchema](api:SilverStripe\ORM\DataObjectSchema) methods such as `baseDataTable()`, `tableName()`, and `tableForField()` to get the appropriate table names if you need to write raw SQL queries.
+
+## Features and enhancements {#features-and-enhancements}
+
+### Extension changes
+[Extension](api:SilverStripe\Core\Extension) classes don't expose `protected` methods, but they _can_ be used for extension hooks. This reduces the surface of methods exposed from your extensions into `Extensible` classes. For example, you might have a `protected function updateCMSFields()` method which will be called after writing some `DataObject` - but because this method is `protected`, it _cannot_ be accessed directly from the `DataObject` instances. You can however still expose some method from the `Extension` by making it `public` - and that method _can_ be accessed directly from the `DataObject` instances.
+
+When invoking an extension hook (e.g. via `extend()`), methods prefixed with "extend" will take precendence. i.e. if an `Extension` class has a `onAfterWrite()` method and an `extendOnAfterWrite()` method and I call `$this->extend('onAfterWrite')` - the `extendOnAfterWrite()` method on that `Extension` will be called, and `onAfterWrite()` will not.  
+This empowers advanced `Extension` functionality such as [Versioned::canPublish()](api:SilverStripe\Versioned\Versioned::canPublish()) which invokes `$owner->extendedCan('canPublish')` but doesn't result in a cycle, because the same class also implements [extendCanPublish()](api:SilverStripe\Versioned\Versioned::extendCanPublish()).
+
+### Other new features {#other-features}
+
+- [DataObject::get_one()][api:SilverStripe\ORM\DataObject::get_one()] can now be called directly from subclasses of `DataObject` without passing in a class as the first argument (e.g. `SiteTree::get_one(filter: ['Title:startsWith' => 'About'])`).
+
+## Bugfixes {#bugfixes}
+
+- If a page which is a child of a root-level page gets archived, and then its former parent is removed, it can only be restored if `can_be_root` for that page's class is true.
+
+This release includes a number of bug fixes to improve a broad range of areas. Check the change logs for full details of these fixes split by module. Thank you to the community members that helped contribute these fixes as part of the release!
+
+<!--- Changes below this line will be automatically regenerated -->
+
+<!--- Changes above this line will be automatically regenerated -->


### PR DESCRIPTION
Note: I fully expect that eventually the content in the changelog and the upgrading section will end up swapping around so that the changelog will just list the literal changes and upgrading section will include the upgrade notes.

But for now let's just keep going the way we have been, listing raw changes in the upgrade doc. We can swap these around however we decide to when we get closer to doing a release.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350