### PR TITLE
fix: add missing highlighting to code example

### DIFF
--- a/en/02_Developer_Guides/03_Forms/How_Tos/06_Handle_Nested_data.md
+++ b/en/02_Developer_Guides/03_Forms/How_Tos/06_Handle_Nested_data.md
@@ -207,7 +207,7 @@ rather than relying on form field logic.
 
 Example: Create one or more new teams for existing player
 
-```
+```php
 <?php
 
 use SilverStripe\Control\Controller;


### PR DESCRIPTION
The fenced code block was missing the `php` type.