### PR TITLE
DOC Update preview docs with correct information

### DIFF
--- a/en/02_Developer_Guides/15_Customising_the_Admin_Interface/04_Preview.md
+++ b/en/02_Developer_Guides/15_Customising_the_Admin_Interface/04_Preview.md
@@ -57,14 +57,9 @@ The format for that situation is always the same, with increasing complexity if 
 nesting `GridField`s. For the below examples it is assumed you aren't using nested
 `GridField`s.
 
-If your object belongs to a page, you can safely get away with returning `null` or an empty
-string, as it won't be used. You can choose to return a valid edit link, but because of the
-complexity of the way these links are generated it would be difficult to do so in a general,
-reusable way.
-
 [hint]
 As of Silverstripe CMS 4.12.0, you can
-[use CMSEditLinkExtension](/developer_guides/model/data_model_and_orm/managing_records#getting-an-edit-link).
+[use CMSEditLinkExtension](/developer_guides/model/managing_records#getting-an-edit-link).
 
 ```php
 namespace MyProject\Model;


### PR DESCRIPTION
Fixes a broken link and removes the implication that implementing `CMSEditLink()` is hard, since as of 4.12 it won't be.

## Parent issue
- https://github.com/silverstripe/developer-docs/issues/96