### PR TITLE
Use X-Status header for status messages

### DIFF
--- a/en/02_Developer_Guides/03_Forms/How_Tos/04_Create_a_GridField_ActionProvider.md
+++ b/en/02_Developer_Guides/03_Forms/How_Tos/04_Create_a_GridField_ActionProvider.md
@@ -96,10 +96,9 @@ class GridFieldCustomAction extends AbstractGridFieldComponent implements GridFi
         // perform your action here
 
         // output a success message to the user
-        Controller::curr()->getResponse()->setStatusCode(
-            200,
-            'Do Custom Action Done.'
-        );
+        Controller::curr()->getResponse()
+            ->setStatusCode(200)
+            ->addHeader('X-Status', 'Do Custom Action Done.');
     }
 }
 ```
@@ -274,10 +273,9 @@ class GridFieldCustomAction extends AbstractGridFieldComponent implements GridFi
         // perform your action here
 
         // output a success message to the user
-        Controller::curr()->getResponse()->setStatusCode(
-            200,
-            'Do Custom Action Done.'
-        );
+        Controller::curr()->getResponse()
+            ->setStatusCode(200)
+            ->addHeader('X-Status', 'Do Custom Action Done.');
     }
 }
 ```

--- a/en/02_Developer_Guides/15_Customising_the_Admin_Interface/06_Javascript_Development.md
+++ b/en/02_Developer_Guides/15_Customising_the_Admin_Interface/06_Javascript_Development.md
@@ -411,7 +411,9 @@ class MyController
     if(!$results) return new HTTPResponse("Not found", 404);
 
     // Use HTTPResponse to pass custom status messages
-    $this->getResponse()->setStatusCode(200, "Found " . $results->Count() . " elements");
+    $this->getResponse()
+      ->setStatusCode(200)
+      ->addHeader('X-Status', "Found " . $results->Count() . " elements");
 
     // render all results with a custom template
     $vd = new ViewableData();


### PR DESCRIPTION
Issue https://github.com/silverstripe/developer-docs/issues/103

HTTP/2 protocol doesn't support status messages so we need to use the X-Status header to display toast notifications correctly