### PR TITLE
MNT Update branch which triggers deploying docs site

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - '3'
-      - '4.11'
+      - '4.12'
       - '5'
 jobs:
   build:


### PR DESCRIPTION
Updates the branch which triggers deploying docs.silverstripe.org

Note: This is targetting `4` because that's the default branch - this would not actually do anything if it targetted `4.12` which would mean we'd have to do a premature merge-up for it.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/606