### PR TITLE
MNT Update branch which triggers deploying docs site

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - '3'
-      - '4.11'
+      - '4.12'
 jobs:
   build:
     name: build-docs


### PR DESCRIPTION
Backport of https://github.com/silverstripe/developer-docs/pull/110

It turns out it's not the default branch that cares about this - instead, each individual branch cares about it separately. So we need to tell `4.11` that it's not on the list anymore, and then tell `4.12` via a merge-up that it _is_ on the list now.