### PR TITLE
DOC Fix two small typos in 4.12 changelogs

### DIFF
--- a/en/04_Changelogs/4.12.0.md
+++ b/en/04_Changelogs/4.12.0.md
@@ -265,13 +265,13 @@ Silverstripe CMS 4 includes multiple tasks to migrate files to newer states. The
 
 ### Other new features {#other-features}
 
-- `extra_fields` data for a [ManyManyList](api:SilverStripe\ORM\ManyManyList) can now be set easily with the ORM - simply call the [setExtraData()](api:SilverStripe\ORM\ManyManyList::setExtraData()) method. See [the `many_many` documentation](/developer_guides/model/relations#many_many) for more details.
+- `extra_fields` data for a [ManyManyList](api:SilverStripe\ORM\ManyManyList) can now be set easily with the ORM - simply call the [setExtraData()](api:SilverStripe\ORM\ManyManyList::setExtraData()) method. See [the `many_many` documentation](/developer_guides/model/relations#many-many) for more details.
 
 ## Bugfixes {#bugfixes}
 
 This release includes a number of bug fixes to improve a broad range of areas. Check the change logs for full details of these fixes split by module. Thank you to the community members that helped contribute these fixes as part of the release!
 
-### Deprecation class(#deprecation-class)
+### Deprecation class {#deprecation-class}
 
 The [Deprecation](api:SilverStripe\Dev\Deprecation) class did not function correctly when used with modules that had a version less than `4.0.0`, notably modules such as `silverstripe/admin` which has a major version of `1`. The old "version filtering" functionality has been replaced with a simple call to `Deprecation::enabled()` that will show all deprecation notices, regardless of the version passed as the first parameter.
 

--- a/en/04_Changelogs/beta/4.12.0-beta1.md
+++ b/en/04_Changelogs/beta/4.12.0-beta1.md
@@ -340,13 +340,13 @@ Silverstripe CMS 4 includes multiple tasks to migrate files to newer states. The
 
 ### Other new features {#other-features}
 
-- `extra_fields` data for a [ManyManyList](api:SilverStripe\ORM\ManyManyList) can now be set easily with the ORM - simply call the [setExtraData()](api:SilverStripe\ORM\ManyManyList::setExtraData()) method. See [the `many_many` documentation](/developer_guides/model/relations#many_many) for more details.
+- `extra_fields` data for a [ManyManyList](api:SilverStripe\ORM\ManyManyList) can now be set easily with the ORM - simply call the [setExtraData()](api:SilverStripe\ORM\ManyManyList::setExtraData()) method. See [the `many_many` documentation](/developer_guides/model/relations#many-many) for more details.
 
 ## Bugfixes {#bugfixes}
 
 This release includes a number of bug fixes to improve a broad range of areas. Check the change logs for full details of these fixes split by module. Thank you to the community members that helped contribute these fixes as part of the release!
 
-### Deprecation class(#deprecation-class)
+### Deprecation class {#deprecation-class}
 
 The [Deprecation](api:SilverStripe\Dev\Deprecation) class did not function correctly when used with modules that had a version less than `4.0.0`, notably modules such as `silverstripe/admin` which has a major version of `1`. The old "version filtering" functionality has been replaced with a simple call to `Deprecation::enabled()` that will show all deprecation notices, regardless of the version passed as the first parameter.
 

--- a/en/04_Changelogs/rc/4.12.0-rc1.md
+++ b/en/04_Changelogs/rc/4.12.0-rc1.md
@@ -345,13 +345,13 @@ Silverstripe CMS 4 includes multiple tasks to migrate files to newer states. The
 
 ### Other new features {#other-features}
 
-- `extra_fields` data for a [ManyManyList](api:SilverStripe\ORM\ManyManyList) can now be set easily with the ORM - simply call the [setExtraData()](api:SilverStripe\ORM\ManyManyList::setExtraData()) method. See [the `many_many` documentation](/developer_guides/model/relations#many_many) for more details.
+- `extra_fields` data for a [ManyManyList](api:SilverStripe\ORM\ManyManyList) can now be set easily with the ORM - simply call the [setExtraData()](api:SilverStripe\ORM\ManyManyList::setExtraData()) method. See [the `many_many` documentation](/developer_guides/model/relations#many-many) for more details.
 
 ## Bugfixes {#bugfixes}
 
 This release includes a number of bug fixes to improve a broad range of areas. Check the change logs for full details of these fixes split by module. Thank you to the community members that helped contribute these fixes as part of the release!
 
-### Deprecation class(#deprecation-class)
+### Deprecation class {#deprecation-class}
 
 The [Deprecation](api:SilverStripe\Dev\Deprecation) class did not function correctly when used with modules that had a version less than `4.0.0`, notably modules such as `silverstripe/admin` which has a major version of `1`. The old "version filtering" functionality has been replaced with a simple call to `Deprecation::enabled()` that will show all deprecation notices, regardless of the version passed as the first parameter.
 


### PR DESCRIPTION
Fix a couple of small typos I noticed in the 4.12 changelogs