### PR TITLE
DOC Fix typo in 4.12 changelog

### DIFF
--- a/en/04_Changelogs/4.12.0.md
+++ b/en/04_Changelogs/4.12.0.md
@@ -105,7 +105,7 @@ A full list of module versions included in CMS Recipe 4.12.0-rc1 is provided bel
 
 ## Security considerations {#security-considerations}
 
-This release include a security fix for the `silverstripe/subsite` module. Review the vulnerability disclosure for more detailed. We highly encourage upgrading your project to include the latest security patch if your project requires `silverstripe/subsite`.
+This release include a security fix for the `silverstripe/subsites` module. Review the vulnerability disclosure for more detailed. We highly encourage upgrading your project to include the latest security patch if your project requires `silverstripe/subsites`.
 
 We have provided a high-level severity rating of the vulnerability below based on its CVSS score. Note that the impact of the vulnerability could vary based on the specifics of each project. You can [read the severity rating definitions in the Silverstripe CMS release process](/contributing/release_process/#severity-rating).
 


### PR DESCRIPTION
The Subsite module's name is `silverstripe/subsites` with an S.