### PR TITLE
DOC Stop saying jQuery is legacy - it'll be around for a while.

### DIFF
--- a/en/02_Developer_Guides/15_Customising_the_Admin_Interface/02_CMS_Architecture.md
+++ b/en/02_Developer_Guides/15_Customising_the_Admin_Interface/02_CMS_Architecture.md
@@ -250,10 +250,11 @@ correctly configured form.
 
 ## JavaScript through jQuery.entwine
 
-__Deprecated:__
-The following documentation regarding Entwine applies to legacy code only.
+[notice]
+The following documentation regarding Entwine does not apply to React components or sections powered by React.
 If you're developing new functionality in React powered sections please refer to
 [ReactJS in Silverstripe CMS](./How_Tos/Extend_CMS_Interface.md#reactjs-in-silverstripe).
+[/notice]
 
 [jQuery.entwine](https://github.com/hafriedlander/jquery.entwine) is a thirdparty library
 which allows us to attach behaviour to DOM elements in a flexible and structured mannger.

--- a/en/02_Developer_Guides/15_Customising_the_Admin_Interface/03_CMS_Layout.md
+++ b/en/02_Developer_Guides/15_Customising_the_Admin_Interface/03_CMS_Layout.md
@@ -5,10 +5,11 @@ summary: Add interactivity enhancements to the admin with Javascript
 
 # CMS layout
 
-__Deprecated:__
-The following documentation regarding JavaScript layouts applies to legacy code only.
+[notice]
+The following documentation regarding JavaScript layouts does not apply to React components or sections powered by React.
 If you're developing new functionality in React powered sections please refer to
 [ReactJS in Silverstripe CMS](./how_tos/extend_cms_interface/#react-rendered-ui).
+[/notice]
 
 The CMS markup is structured into "panels", which are the base units containing interface components (or other panels),
 as declared by the class `cms-panel`. Panels can be made collapsible, and get the ability to be resized and aligned with

--- a/en/02_Developer_Guides/15_Customising_the_Admin_Interface/06_Javascript_Development.md
+++ b/en/02_Developer_Guides/15_Customising_the_Admin_Interface/06_Javascript_Development.md
@@ -23,10 +23,11 @@ in a browser. This transpiling can be done using a variety of toolchains, but th
    * [Babel](http://babeljs.io) (ES6 transpiler)
    * [Webpack](http://webpack.js.org) (Module bundler)
 
-__Deprecated:__
-The following documentation regarding jQuery, jQueryUI and Entwine applies to legacy code only.
+[notice]
+The following documentation regarding jQuery, jQueryUI and Entwine does not apply to React components or sections powered by React.
 If you're developing new functionality in React powered sections please refer to
 [ReactJS, Redux, and GraphQL](./reactjs_redux_and_graphql).
+[/notice]
 
 ## jQuery, jQuery UI and jQuery.entwine: Our libraries of choice
 

--- a/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/CMS_Alternating_Button.md
+++ b/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/CMS_Alternating_Button.md
@@ -73,10 +73,11 @@ public function getCMSActions()
 
 ## Frontend support
 
-__Deprecated:__
-The following documentation regarding jQuery, jQueryUI and Entwine applies to legacy code only.
+[notice]
+The following documentation regarding jQuery, jQueryUI and Entwine does not apply to React components or sections powered by React.
 If you're developing new functionality in React powered sections please refer to
 [ReactJS in Silverstripe CMS](./extend_cms_interface.md#reactjs-in-silverstripe).
+[/notice]
 
 As with the *Save* and *Save & publish* buttons, you might want to add some scripted reactions to user actions on the
 frontend. You can affect the state of the button through the jQuery UI calls.


### PR DESCRIPTION
jQuery and entwine are going to be around for the forseeable future - instead of saying it's legacy and potentially scaring people away from doing things _the actual way things are still done_, we should simply be stating the fact that it's not related to the react stuff.

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1318