### PR TITLE
DOC: improve consistency of SilverStripe spelling

### DIFF
--- a/en/05_Contributing/05_Making_A_SilverStripe_Core_Release.md
+++ b/en/05_Contributing/05_Making_A_SilverStripe_Core_Release.md
@@ -1,10 +1,10 @@
 ---
-title: Making a Silverstripe CMS core release
+title: Making a SilverStripe CMS core release
 summary: Development guide for core contributors to build and publish a new release
 iconBrand: github-alt
 ---
 
-# Making a Silverstripe CMS core release
+# Making a SilverStripe CMS core release
 
 ## Introduction
 
@@ -16,7 +16,7 @@ The artifacts for this process are typically:
  * A published announcement
  * A new composer installable stable tag for silverstripe/installer
 
-While this document is not normally applicable to normal silverstripe contributors,
+While this document is not normally applicable to normal SilverStripe contributors,
 it is still useful to have it available in a public location so that these users
 are aware of these processes.
 

--- a/en/05_Contributing/07_Translations.md
+++ b/en/05_Contributing/07_Translations.md
@@ -47,14 +47,14 @@ on github, you can create a fork, edit the files, and send back your pull reques
 ### How do I translate substituted strings? (e.g. '%s' or '{my-variable}')
 
 You don't have to - if the english master-string reads 'Hello %s', your german translation would be 'Hallo %s'. Strings 
-prefixed by a percentage-sign are automatically replaced by silverstripe with dynamic content. See 
+prefixed by a percentage-sign are automatically replaced by SilverStripe with dynamic content. See 
 http://php.net/sprintf for details. The newer `{my-variable}` format works the same way, but makes its intent clearer, 
 and allows reordering of placeholders in your translation.
 
 ### Do I need to convert special characters (e.g. HTML-entities)?
 
 Special characters (such as german umlauts) need to be entered in their native form. Please don't use HTML-entities 
-("ä" instead of "ä"). Silverstripe stores and renders most strings in UTF8 (Unicode) format.
+("ä" instead of "ä"). SilverStripe stores and renders most strings in UTF8 (Unicode) format.
 
 ### How can I check out my translation in the interface?
 
@@ -85,7 +85,7 @@ dropdown which automatically includes all found translations (based on the files
 
 ### I've found a piece of untranslatable text
 
-It is entirely possible that we missed certain strings in preparing Silverstripe for translation-support. If you're 
+It is entirely possible that we missed certain strings in preparing SilverStripe for translation-support. If you're 
 technically minded, please read [i18n](../developer_guides/i18n) on how to make it translatable. Otherwise just post your findings 
 to the forum.
 
@@ -101,7 +101,7 @@ tool, and wait for your translators to do their magic!
 SilverStripe doesn't have built-in support for attribute-based RTL-modifications (`<html dir="rtl">`). 
 
 We are currently investigating the available options, and are eager to get feedback on your experiences with 
-translating silverstripe RTL.
+translating SilverStripe RTL.
 
 ### Can I translate/edit the language files in my favorite text editor (on my local installation)
 
@@ -144,7 +144,7 @@ channel. For generic translation and Transifex questions you might like to use
 
 ## Related
 
- * [i18n](/developer_guides/i18n): Developer-level documentation of Silverstripe's i18n capabilities
+ * [i18n](/developer_guides/i18n): Developer-level documentation of SilverStripe's i18n capabilities
  * [Translation Process](translation_process): Information about managing translations for the core team and/or module maintainers.
  * [translatable](https://github.com/silverstripe/silverstripe-translatable): DataObject-interface powering the website-content translations
  * `["Translatable ModelAdmin" module](http://silverstripe.org/translatablemodeladmin-module/)`: An extension which allows translations of DataObjects inside ModelAdmin

--- a/en/05_Contributing/index.md
+++ b/en/05_Contributing/index.md
@@ -4,8 +4,8 @@ summary: Any open source product is only as good as the community behind it. You
 icon: heart
 ---
 
-## House rules for everybody contributing to Silverstripe CMS
- * Read over the Silverstripe CMS Community [Code of Conduct](/project_governance/code_of_conduct) 
+## House rules for everybody contributing to SilverStripe CMS
+ * Read over the SilverStripe CMS Community [Code of Conduct](/project_governance/code_of_conduct) 
  * Ask questions on the [forum](http://silverstripe.org/community/forums)
  * Make sure you know how to [raise good bug reports](issues_and_bugs)
  * Everybody can contribute to SilverStripe! If you do, ensure you can [submit solid pull requests](code)

--- a/en/06_Project_Governance/01_Core_committers.md
+++ b/en/06_Project_Governance/01_Core_committers.md
@@ -6,7 +6,7 @@ icon: users
 
 # Core Committers
 
-The Core Committers team is reviewed approximately annually, new members are added based on quality contributions to Silverstripe CMS code and outstanding community participation.
+The Core Committers team is reviewed approximately annually, new members are added based on quality contributions to SilverStripe CMS code and outstanding community participation.
 
 This page outlines those who are part of the Core Committer team and outlines the process for onboarding new members.
 

--- a/en/06_Project_Governance/02_Code_of_conduct.md
+++ b/en/06_Project_Governance/02_Code_of_conduct.md
@@ -3,11 +3,11 @@ title: Code of conduct
 summary: How to be a high-performing, helpful member of our community
 icon: handshake
 ---
-# Silverstripe CMS community code of conduct
+# SilverStripe CMS community code of conduct
 
-These guidelines aim to be an aspirational ideal for how we should behave when interacting in the Silverstripe CMS developer community and to aid in building great open source software.
+These guidelines aim to be an aspirational ideal for how we should behave when interacting in the SilverStripe CMS developer community and to aid in building great open source software.
 
-This code of conduct should be applied to all discussions and interactions involving Silverstripe CMS and its related resources.
+This code of conduct should be applied to all discussions and interactions involving SilverStripe CMS and its related resources.
 
 Honour the code of conduct whenever you participate formally and informally in our community and follow it in spirit as much as in letter.
 
@@ -35,7 +35,7 @@ Honour the code of conduct whenever you participate formally and informally in o
  * All contributors and core committers, module maintainers and knowledge sharers are participating in the community in a voluntary nature. Have respect for them and their time when making requests. You may need to exercise some patience.
  * Whenever possible, reference your comments to others with example code or links to documentation. This helps people learn and become more experienced community members and developers.
  * If you manage to solve your own problem, tell others how you solved it. This will help people in the future who have to solve similar problems.
- * If you are reducing your input, and potentially stepping away from the community, please remember that others might be relying on your contributions. Be prepared to ensure your contributions remain open and available to the community. Spend some time handing your contributions over to another community member or core contributor to help with the continuity of Silverstripe CMS open source development.
+ * If you are reducing your input, and potentially stepping away from the community, please remember that others might be relying on your contributions. Be prepared to ensure your contributions remain open and available to the community. Spend some time handing your contributions over to another community member or core contributor to help with the continuity of SilverStripe CMS open source development.
 
 ## Resolve conflicts directly
  * Conflict may eventuate from time to time. We should all try to view it as a constructive process. Understanding others' positions, without descending into ad hominem attacks, is valuable and may lead to better solutions to problems.
@@ -49,12 +49,12 @@ Honour the code of conduct whenever you participate formally and informally in o
 ## A living document
  * This is a living document. As core committers, we know we don't have all the answers so we want to make the community an innovative and valuable space for everyone that wishes to contribute.
 
- * If you would like to improve the wording, add additional items, or simply fix typos, each contribution to the code of conduct will be considered on it's merit and agreed upon unanimously by the core committers. Any changes will be included in future revisions of the Silverstripe CMS code of conduct.
+ * If you would like to improve the wording, add additional items, or simply fix typos, each contribution to the code of conduct will be considered on it's merit and agreed upon unanimously by the core committers. Any changes will be included in future revisions of the SilverStripe CMS code of conduct.
 
 ## Core committers house rules
 Core committers are also bound by their [own set of house rules](core_committers#house_rules_for_the_core_committer_team).
 
-_The Silverstripe CMS code of conduct has been adapted from the following sources:_
+_The SilverStripe CMS code of conduct has been adapted from the following sources:_
 
 http://www.apache.org/foundation/policies/conduct.html
 

--- a/en/06_Project_Governance/03_Maintainer_Guidelines.md
+++ b/en/06_Project_Governance/03_Maintainer_Guidelines.md
@@ -7,23 +7,23 @@ iconBrand: wpforms
 
 # Maintainer Guidelines
 
-This doc outlines expectations on maintainers of Silverstripe Core. It also forms the default expectations for maintainers of Supported Modules, unless more specific contribution guidelines are available for a module.
+This doc outlines expectations on maintainers of SilverStripe Core. It also forms the default expectations for maintainers of Supported Modules, unless more specific contribution guidelines are available for a module.
 
 Module maintainers are people taking care of the repositories, CI, documentation, source code, conventions, community communications, issue triage, and release management.
 
 One of the most important maintainer responsibilities is to collaborate with other maintainers. Another important role is to facilitate community contributions (such as issue reports and pull requests).
 
 [note]
-A lot of extra information is available in Silverstripe CMS documentation section [“Contributing to Silverstripe”](./).
+A lot of extra information is available in SilverStripe CMS documentation section [“Contributing to SilverStripe”](./).
 All maintainers should be familiar with those docs as they explain many details about how we work.
 [/note]
 
 
-## What is Silverstripe Core
+## What is SilverStripe Core
 
-Silverstripe CMS is powered by a system of components in the form of Composer packages. These packages will be categorised as either a _module_ or a _recipe_.
+SilverStripe CMS is powered by a system of components in the form of Composer packages. These packages will be categorised as either a _module_ or a _recipe_.
 
-The "core" of Silverstripe refers to the module packages owned by the "silverstripe" Packagist vendor that fall under one of the following recipes:
+The "core" of SilverStripe refers to the module packages owned by the "silverstripe" Packagist vendor that fall under one of the following recipes:
 
 * [silverstripe/recipe-core](https://github.com/silverstripe/recipe-cms)
 * [silverstripe/recipe-cms](https://github.com/silverstripe/recipe-cms)
@@ -31,7 +31,7 @@ The "core" of Silverstripe refers to the module packages owned by the "silverstr
 
 ## What are Supported Modules
 
-In addition to Silverstripe Core, there are many [Supported Modules](https://www.silverstripe.org/software/addons/supported-modules-definition/)
+In addition to SilverStripe Core, there are many [Supported Modules](https://www.silverstripe.org/software/addons/supported-modules-definition/)
 which have the backing of Silverstripe Ltd. While it's a good idea to apply the rules outlined in this document,
 work on these modules is guided by the 
 [Supported Modules Standard](https://www.silverstripe.org/software/addons/supported-modules-definition/).
@@ -43,7 +43,7 @@ or any additional guidelines outlined via `README` and `CONTRIBUTING` files.
 
 ### Core Committers
 
-The people looking after the Silverstripe Core modules.
+The people looking after the SilverStripe Core modules.
 See the details on the [Core Committers](./core_committers) page.
 
 
@@ -94,10 +94,10 @@ First and foremost rule of a maintainer is to collaborate with other maintainers
  * Follow [Semantic Versioning](code/#picking-the-right-version) by putting any changes into the correct branch
  * API changes and non-trivial features should not be merged into release branches. 
  * API changes on master should not be merged until they have the buy-in of at least two Core Committers (or better, through the [core mailing list](https://groups.google.com/forum/#!forum/silverstripe-dev))
- * Be inclusive. Ensure a wide range of Silverstripe CMS developers can obtain an understanding of your code and docs, and you're not the only one who can maintain it.
+ * Be inclusive. Ensure a wide range of SilverStripe CMS developers can obtain an understanding of your code and docs, and you're not the only one who can maintain it.
  * Avoid `git push --force`, and be careful with your git remotes (no accidental pushes)
  * Use your own forks to create feature branches
- * We release using the standard process. See the [Making a Silverstripe CMS Core Release](making_a_silverstripe_core_release)
+ * We release using the standard process. See the [Making a SilverStripe CMS Core Release](making_a_silverstripe_core_release)
 
 
 ### How to triage

--- a/en/06_Project_Governance/05_Major_release_policy.md
+++ b/en/06_Project_Governance/05_Major_release_policy.md
@@ -1,6 +1,6 @@
 ---
 title: Major Release Policy
-summary: Outline the major release lifecycle and support commitment for Silverstripe CMS
+summary: Outline the major release lifecycle and support commitment for SilverStripe CMS
 icon: code-branch
 ---
 
@@ -8,17 +8,17 @@ icon: code-branch
 
 ## Scope of the policy
 
-This policy applies to all [Silverstripe CMS commercially supported modules](https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/).
+This policy applies to all [SilverStripe CMS commercially supported modules](https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/).
 
 Community modules are not covered by this policy. Modules in the `silverstripe` github organisation that are not commercially supported are updated on a best effort basis.
 
 ## General approach to major releases
 
-Silverstripe CMS aims to deliver regular major releases at predefined intervals with a clear support timeline. The key objective of this policy is to allow Silverstripe CMS project owners to plan major upgrades ahead of time.
+SilverStripe CMS aims to deliver regular major releases at predefined intervals with a clear support timeline. The key objective of this policy is to allow SilverStripe CMS project owners to plan major upgrades ahead of time.
 
 The main function of major releases is to ship *breaking changes* that can not be shipped in minor releases. These changes are primarily aimed at making sure the major releases can be supported for the full duration of its lifecycle.
 
-The lifecycle for a Silverstripe CMS major release line is:
+The lifecycle for a SilverStripe CMS major release line is:
 - pre-release (undefined duration)
 - active development (2 years)
 - bug and security fixes (1 year)
@@ -35,15 +35,15 @@ At launch, major releases may contain new features not present in the previous m
 
 Major releases are not backward compatible. Most projects will require at least some development work to upgrade to a new major release.
 
-Silverstripe CMS provides a [clear upgrade path](/upgrading) to new major releases. This includes clear documentation on what breaking changes have been made to each area of Silverstripe CMS.
+SilverStripe CMS provides a [clear upgrade path](/upgrading) to new major releases. This includes clear documentation on what breaking changes have been made to each area of SilverStripe CMS.
 
 ## Major release lifecycle
 
-A Silverstripe CMS major release line follows a predefined life cycle. New Silverstripe CMS majors are released in odd years (e.g. 2023, 2025, 2027, etc). At any given time, only two major release lines are officially supported.
+A SilverStripe CMS major release line follows a predefined life cycle. New SilverStripe CMS majors are released in odd years (e.g. 2023, 2025, 2027, etc). At any given time, only two major release lines are officially supported.
 
 ### Pre-release
 
-A Silverstripe CMS stable major release is preceded by a beta period of at least three months.
+A SilverStripe CMS stable major release is preceded by a beta period of at least three months.
 
 The purpose of the beta period is to:
 
@@ -57,7 +57,7 @@ Prior to the beta period, alpha releases are published at the discretion of the 
 
 ### Stable release
 
-New major releases of Silverstripe CMS are tagged between April and June of odd years.
+New major releases of SilverStripe CMS are tagged between April and June of odd years.
 
 ### Active development
 
@@ -72,7 +72,7 @@ Only one major release line is in *active development* at any given time.
 
 ### Bug and security fixes
 
-A Silverstripe CMS major release line enters the *bug and security fixes* phase once the follow major release is tagged stable.
+A SilverStripe CMS major release line enters the *bug and security fixes* phase once the follow major release is tagged stable.
 
 A major release line in the *bug and security fixes* phase receives:
 - regular patches for bugs at all impact levels
@@ -87,57 +87,57 @@ A major release line stays in the *bug and security fixes* phase for 1 year.
 
 ### Security fixes only
 
-At the end of *bug and security fixes* phase, a Silverstripe CMS major release line transitions to the *security fixes only* phase.
+At the end of *bug and security fixes* phase, a SilverStripe CMS major release line transitions to the *security fixes only* phase.
 
-In the *security fixes only* phase, a Silverstripe CMS major release line only receives patches for high impact security issues defined has having a CVSS of 7.0 or above.
+In the *security fixes only* phase, a SilverStripe CMS major release line only receives patches for high impact security issues defined has having a CVSS of 7.0 or above.
 
 ### End-of-life
 
-A Silverstripe CMS major release line reaches *end-of-life* once the next major release line exits active development.
+A SilverStripe CMS major release line reaches *end-of-life* once the next major release line exits active development.
 
 End-of-life major releases do not receive updates of any kind including security fixes or bug fixes.
 
 ## PHP support commitments
 
-Silverstripe CMS major releases track PHP releases. 
+SilverStripe CMS major releases track PHP releases. 
 
-The Silverstripe CMS release cycle is built around these assumptions:
+The SilverStripe CMS release cycle is built around these assumptions:
 
 - new PHP releases are shipped at the end of November on an annual basis
 - PHP releases are in full support for two years with one year of limited support. 
 
-At launch, a Silverstripe CMS major release supports all PHP versions in full support. PHP versions in limited support are not supported at launch by new Silverstripe CMS major releases.
+At launch, a SilverStripe CMS major release supports all PHP versions in full support. PHP versions in limited support are not supported at launch by new SilverStripe CMS major releases.
 
-Following the initial launch of a Silverstripe CMS major release, the development team aims to add forward compatibility for the next PHP release. e.g.: Silverstripe CMS 5 at launch will support PHP 8.1 and PHP 8.2. CMS 5 should receive official support for an eventual PHP 8.3 in early 2024.
+Following the initial launch of a SilverStripe CMS major release, the development team aims to add forward compatibility for the next PHP release. e.g.: SilverStripe CMS 5 at launch will support PHP 8.1 and PHP 8.2. CMS 5 should receive official support for an eventual PHP 8.3 in early 2024.
 
-Support for end-of-life PHP releases is not dropped within a Silverstripe CMS major release line, unless it's necessary to address vulnerabilities or high impact bugs.
+Support for end-of-life PHP releases is not dropped within a SilverStripe CMS major release line, unless it's necessary to address vulnerabilities or high impact bugs.
 
 Major release lines not in active development do not receive official support for later PHP releases.
 
 ## Dependency management
 
-At launch, Silverstripe CMS major releases aim to have all PHP and JavaScript dependencies on their latest stable versions. For dependencies offering a *Long Term Support* version, the latest LTS of that dependency is preferred.
+At launch, SilverStripe CMS major releases aim to have all PHP and JavaScript dependencies on their latest stable versions. For dependencies offering a *Long Term Support* version, the latest LTS of that dependency is preferred.
 
-A list of *fixed dependencies* for each Silverstripe CMS major release line is explicitly defined by the development team. *Fixed dependencies* do not change for the lifetime of a Silverstripe CMS major release line.
+A list of *fixed dependencies* for each SilverStripe CMS major release line is explicitly defined by the development team. *Fixed dependencies* do not change for the lifetime of a SilverStripe CMS major release line.
 
-Support for newer major releases of fixed dependencies is not added to Silverstripe CMS major release line, even if the currently used version is end-of-life. The only exception is if the upgrade is necessary to fix a high impact bug or security vulnerability. A Silverstripe CMS major release line only supports one major version of each fixed dependency.
+Support for newer major releases of fixed dependencies is not added to SilverStripe CMS major release line, even if the currently used version is end-of-life. The only exception is if the upgrade is necessary to fix a high impact bug or security vulnerability. A SilverStripe CMS major release line only supports one major version of each fixed dependency.
 
-Non-fixed dependencies may be upgraded to new major releases or swapped out altogether within a Silverstripe CMS release line.
+Non-fixed dependencies may be upgraded to new major releases or swapped out altogether within a SilverStripe CMS release line.
 
 ### Symfony support commitments
 
-Symfony is a collection of common PHP libraries Silverstripe CMS uses. At launch, Silverstripe CMS major releases track the latest stable major version of Symfony dependencies. A Silverstripe CMS major release line does not add support for later Symfony major versions.
+Symfony is a collection of common PHP libraries SilverStripe CMS uses. At launch, SilverStripe CMS major releases track the latest stable major version of Symfony dependencies. A SilverStripe CMS major release line does not add support for later Symfony major versions.
 
 ## Commercially supported module
 
 Commercially supported modules are reviewed with each new major release. At launch, the list of commercially supported modules for that release line is explicitly defined.
 
-New modules may be added to the commercially supported modules list during a Silverstripe CMS major release line's lifespan. Modules are not withdrawn from the commercially supported modules list for a Silverstripe CMS major releases line unless external factors make it impractical to continue support. e.g. The module requires a discontinued third party service to work as intended.
+New modules may be added to the commercially supported modules list during a SilverStripe CMS major release line's lifespan. Modules are not withdrawn from the commercially supported modules list for a SilverStripe CMS major releases line unless external factors make it impractical to continue support. e.g. The module requires a discontinued third party service to work as intended.
 
 Modules that are supported for one major release line may not be supported for follow up release lines.
 
-## Expected Silverstripe CMS major release timeline
+## Expected SilverStripe CMS major release timeline
 
 This timeline is provided as an indication only.
 
-![Timeline of planned Silverstripe CMS major releases](../_images/major_release_timeline.jpg)
+![Timeline of planned SilverStripe CMS major releases](../_images/major_release_timeline.jpg)


### PR DESCRIPTION
As per the docs:

> "SilverStripe" should always appear without a space with both "S"s capitalised.