### PR TITLE
DOC Fix Issues on Common_Subclasses Page

### DIFF
--- a/en/02_Developer_Guides/03_Forms/Field_types/01_Common_Subclasses.md
+++ b/en/02_Developer_Guides/03_Forms/Field_types/01_Common_Subclasses.md
@@ -29,7 +29,7 @@ on the Silverstripe CMS API documentation.
  * [DateField](api:SilverStripe\Forms\DateField): Represents a date in a single input field, or separated into day, month, and year. Can optionally use a calendar popup.
  * [DatetimeField](api:SilverStripe\Forms\DatetimeField): Combined date- and time field.
  * [EmailField](api:SilverStripe\Forms\EmailField): Text input field with validation for correct email format according to RFC 2822.
- * [GroupedDropdownField](api:SilverStripe\Forms\GroupedDropdownField): Grouped dropdown, using <optgroup> tags.
+ * [GroupedDropdownField](api:SilverStripe\Forms\GroupedDropdownField): Grouped dropdown, using `<optgroup>` tags.
  * [HtmlEditorField](api:SilverStripe\Forms\HTMLEditor\HtmlEditorField): A WYSIWYG editor interface.
  * [DBMoneyField](api:SilverStripe\ORM\FieldType\DBMoneyField): A form field that can save into a [DBMoney](api:SilverStripe\ORM\FieldType\DBMoney) database field.
  * [NumericField](api:SilverStripe\Forms\NumericField): Text input field with validation for numeric values.
@@ -55,7 +55,7 @@ doesn't necessarily have any visible styling.
 
  * [CheckboxSetField](api:SilverStripe\Forms\CheckboxSetField): Displays a set of checkboxes as a logical group.
  * [TreeDropdownField](api:SilverStripe\Forms\TreeDropdownField): Dropdown-like field that allows you to select an item from a hierarchical AJAX-expandable tree.
- * [TreeMultiselectField](api:SilverStripe\Forms\TreeMultiselectField): Represents many-many joins using a tree selector shown in a dropdown-like element
+ * [TreeMultiselectField](api:SilverStripe\Forms\TreeMultiselectField): Represents many-many joins using a tree selector shown in a dropdown-like element.
  * [GridField](api:SilverStripe\Forms\GridField\GridField): Displays a [SS_List](api:SilverStripe\ORM\SS_List) in a tabular format. Versatile base class which can be configured to allow editing, sorting, etc.
  * [ListboxField](api:SilverStripe\Forms\ListboxField): Multi-line listbox field, through `<select multiple>`.
 
@@ -63,7 +63,7 @@ doesn't necessarily have any visible styling.
 ## Utility
 
  * [DatalessField](api:SilverStripe\Forms\DatalessField) - Base class for fields which add some HTML to the form but don't submit any data or
-save it to the database
+save it to the database.
  * [HeaderField](api:SilverStripe\Forms\HeaderField): Renders a simple HTML header element.
  * [HiddenField](api:SilverStripe\Forms\HiddenField) - Renders a hidden input field.
  * [LabelField](api:SilverStripe\Forms\LabelField): Simple label tag. This can be used to add extra text in your forms.


### PR DESCRIPTION
Escapes an unescaped `optgroup` tag (see below) and improves consistency for the list elements

![image](https://user-images.githubusercontent.com/27819706/216795473-43d43fe2-e687-424a-a4dc-c3aef72ad192.png)
