### PR TITLE
DOC Update docs for deprecations

### DIFF
--- a/en/02_Developer_Guides/11_Integration/00_CSV_Import.md
+++ b/en/02_Developer_Guides/11_Integration/00_CSV_Import.md
@@ -248,5 +248,4 @@ class PlayerAdmin extends ModelAdmin
 
 ## Related
 
-*  [CsvParser](api:SilverStripe\Dev\CsvParser)
 *  [ModelAdmin](api:SilverStripe\Admin\ModelAdmin)

--- a/en/02_Developer_Guides/11_Integration/How_Tos/custom_csvbulkloader.md
+++ b/en/02_Developer_Guides/11_Integration/How_Tos/custom_csvbulkloader.md
@@ -115,5 +115,4 @@ class PlayerCsvBulkLoader extends CsvBulkLoader
 
 ## Related
 
-*  [CsvParser](api:SilverStripe\Dev\CsvParser)
 *  [ModelAdmin](api:SilverStripe\Admin\ModelAdmin)

--- a/en/04_Changelogs/5.0.0.md
+++ b/en/04_Changelogs/5.0.0.md
@@ -499,7 +499,6 @@ This is a major release and contains many breaking API changes. Deprecation warn
 - Removed deprecated method `SilverStripe\Control\SimpleResourceURLGenerator::resolveUnsecuredResource()`
 - Removed deprecated method `SilverStripe\Core\BaseKernel::getIgnoredCIConfigs()`
 - Removed deprecated method `SilverStripe\Core\BaseKernel::sessionEnvironment()`
-- Removed deprecated method `SilverStripe\Core\Cache\ManifestCacheFactory::createCache()`
 - Removed deprecated method `SilverStripe\Core\ClassInfo::baseDataClass()`
 - Removed deprecated method `SilverStripe\Core\ClassInfo::table_for_object_field()`
 - Removed deprecated method `SilverStripe\Core\Config\Config_ForClass::update()`

--- a/en/04_Changelogs/beta/5.0.0-beta1.md
+++ b/en/04_Changelogs/beta/5.0.0-beta1.md
@@ -717,7 +717,6 @@ This is a major release and contains many breaking API changes. Deprecation warn
 - Removed deprecated method `SilverStripe\Control\SimpleResourceURLGenerator::resolveUnsecuredResource()`
 - Removed deprecated method `SilverStripe\Core\BaseKernel::getIgnoredCIConfigs()`
 - Removed deprecated method `SilverStripe\Core\BaseKernel::sessionEnvironment()`
-- Removed deprecated method `SilverStripe\Core\Cache\ManifestCacheFactory::createCache()`
 - Removed deprecated method `SilverStripe\Core\ClassInfo::baseDataClass()`
 - Removed deprecated method `SilverStripe\Core\ClassInfo::table_for_object_field()`
 - Removed deprecated method `SilverStripe\Core\Config\Config_ForClass::update()`


### PR DESCRIPTION
`ManifestCacheFactory::createCache()` is defined in a parent class so has not technically been removed.

CSVParser has been removed and should not be referenced in docs.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/674