### PR TITLE
DOC Clarification for some removed deprecated class and methods in 5.…

### DIFF
--- a/en/04_Changelogs/5.0.0.md
+++ b/en/04_Changelogs/5.0.0.md
@@ -573,8 +573,6 @@ This is a major release and contains many breaking API changes. Deprecation warn
 - Removed deprecated method `SilverStripe\Admin\ModelAdmin::SearchForm()`
 - Removed deprecated method `SilverStripe\Admin\ModelAdmin::SearchSummary()`
 - Removed deprecated method `SilverStripe\Admin\SecurityAdmin::Backlink()`
-- Removed deprecated method `SilverStripe\Admin\SecurityAdmin::Breadcrumbs()`
-- Removed deprecated method `SilverStripe\Admin\SecurityAdmin::getEditForm()`
 - Removed deprecated method `SilverStripe\Admin\SecurityAdmin::groupimport()`
 - Removed deprecated method `SilverStripe\Admin\SecurityAdmin::GroupImportForm()`
 - Removed deprecated method `SilverStripe\Admin\SecurityAdmin::groups()`
@@ -732,13 +730,13 @@ This is a major release and contains many breaking API changes. Deprecation warn
 
 #### silverstripe/cms
 
+- Class `SilverStripe\CMS\Controllers\SilverStripeNavigator` has been moved from `silverstripe/cms` to `silverstripe/admin` and renamed as [`SilverStripe\Admin\Navigator\SilverStripeNavigator`](api:SilverStripe\Admin\Navigator\SilverStripeNavigator)
+- Class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem` has been moved from `silverstripe/cms` to `silverstripe/admin` and renamed as [`SilverStripe\Admin\Navigator\SilverStripeNavigatorItem`](api:SilverStripe\Admin\Navigator\SilverStripeNavigatorItem)
+- Class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_Unversioned` has been moved from `silverstripe/cms` to `silverstripe/admin` and renamed as [`SilverStripe\Admin\Navigator\SilverStripeNavigatorItem_Unversioned`](api:SilverStripe\Admin\Navigator\SilverStripeNavigatorItem_Unversioned)
+- Class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_ArchiveLink` has been moved from `silverstripe/cms` to `silverstripe/versioned-admin` and renamed as [`SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_ArchiveLink`](api:SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_ArchiveLink)
+- Class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_LiveLink` has been moved from `silverstripe/cms` to `silverstripe/versioned-admin` and renamed as [`SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_LiveLink`](api:SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_LiveLink)
+- Class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_StageLink` has been moved from `silverstripe/cms` to `silverstripe/versioned-admin` and renamed as [`SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_StageLink`](api:SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_StageLink)
 - Removed deprecated class `SilverStripe\CMS\Controllers\CMSPageHistoryController`
-- Removed deprecated class `SilverStripe\CMS\Controllers\SilverStripeNavigator`
-- Removed deprecated class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem`
-- Removed deprecated class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_ArchiveLink`
-- Removed deprecated class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_LiveLink`
-- Removed deprecated class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_StageLink`
-- Removed deprecated class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_Unversioned`
 - Removed deprecated class `SilverStripe\CMS\Model\SiteTreeFileExtension`
 - Removed deprecated class `SilverStripe\CMS\Model\SiteTreeFileFormFactoryExtension`
 - Removed deprecated class `SilverStripe\CMS\Model\SiteTreeFolderExtension`

--- a/en/04_Changelogs/beta/5.0.0-beta1.md
+++ b/en/04_Changelogs/beta/5.0.0-beta1.md
@@ -781,8 +781,6 @@ This is a major release and contains many breaking API changes. Deprecation warn
 - Removed deprecated method `SilverStripe\Admin\ModelAdmin::SearchForm()`
 - Removed deprecated method `SilverStripe\Admin\ModelAdmin::SearchSummary()`
 - Removed deprecated method `SilverStripe\Admin\SecurityAdmin::Backlink()`
-- Removed deprecated method `SilverStripe\Admin\SecurityAdmin::Breadcrumbs()`
-- Removed deprecated method `SilverStripe\Admin\SecurityAdmin::getEditForm()`
 - Removed deprecated method `SilverStripe\Admin\SecurityAdmin::groupimport()`
 - Removed deprecated method `SilverStripe\Admin\SecurityAdmin::GroupImportForm()`
 - Removed deprecated method `SilverStripe\Admin\SecurityAdmin::groups()`
@@ -940,13 +938,13 @@ This is a major release and contains many breaking API changes. Deprecation warn
 
 #### silverstripe/cms
 
+- Class `SilverStripe\CMS\Controllers\SilverStripeNavigator` has been moved from `silverstripe/cms` to `silverstripe/admin` and renamed as [`SilverStripe\Admin\Navigator\SilverStripeNavigator`](api:SilverStripe\Admin\Navigator\SilverStripeNavigator)
+- Class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem` has been moved from `silverstripe/cms` to `silverstripe/admin` and renamed as [`SilverStripe\Admin\Navigator\SilverStripeNavigatorItem`](api:SilverStripe\Admin\Navigator\SilverStripeNavigatorItem)
+- Class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_Unversioned` has been moved from `silverstripe/cms` to `silverstripe/admin` and renamed as [`SilverStripe\Admin\Navigator\SilverStripeNavigatorItem_Unversioned`](api:SilverStripe\Admin\Navigator\SilverStripeNavigatorItem_Unversioned)
+- Class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_ArchiveLink` has been moved from `silverstripe/cms` to `silverstripe/versioned-admin` and renamed as [`SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_ArchiveLink`](api:SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_ArchiveLink)
+- Class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_LiveLink` has been moved from `silverstripe/cms` to `silverstripe/versioned-admin` and renamed as [`SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_LiveLink`](api:SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_LiveLink)
+- Class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_StageLink` has been moved from `silverstripe/cms` to `silverstripe/versioned-admin` and renamed as [`SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_StageLink`](api:SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_StageLink)
 - Removed deprecated class `SilverStripe\CMS\Controllers\CMSPageHistoryController`
-- Removed deprecated class `SilverStripe\CMS\Controllers\SilverStripeNavigator`
-- Removed deprecated class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem`
-- Removed deprecated class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_ArchiveLink`
-- Removed deprecated class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_LiveLink`
-- Removed deprecated class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_StageLink`
-- Removed deprecated class `SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_Unversioned`
 - Removed deprecated class `SilverStripe\CMS\Model\SiteTreeFileExtension`
 - Removed deprecated class `SilverStripe\CMS\Model\SiteTreeFileFormFactoryExtension`
 - Removed deprecated class `SilverStripe\CMS\Model\SiteTreeFolderExtension`


### PR DESCRIPTION
## Description
- Statements regarding renamed and transferred classes have been updated to clarify their current status.
- Clarifications were made regarding removed methods, which are now inherited from the parent class.

## Parent issue
- https://github.com/silverstripe/developer-docs/issues/157