### PR TITLE
DOC Add fluent changes and upgrade guides

### DIFF
--- a/en/04_Changelogs/5.0.0.md
+++ b/en/04_Changelogs/5.0.0.md
@@ -13,6 +13,7 @@ This changelog provides a list of changes between Silverstripe CMS 4 and 5.
 ## Overview
 
 - [Change to commercially supported modules](#supported-modules)
+  - [Modules with upgrade guides](#modules-with-upgrade-guides)
   - [Modules not supported going forward](#modules-not-supported-going-forward)
 - [Fixed dependencies](#fixed-dependencies)
 - [Dependency changes](#dependency-changes)
@@ -44,6 +45,13 @@ This changelog provides a list of changes between Silverstripe CMS 4 and 5.
 Some Silverstripe CMS modules are commercially supported. Silverstripe commits to looking after those modules for the duration of the Silverstripe CMS 5 lifecycle.
 
 Review the list of [Commercially Supported Modules for Silverstripe CMS 5](/project_governance/supported_modules).
+
+### Modules with upgrade guides
+
+`silverstripe/graphql` and `tractorcow/silverstripe-fluent` each have multiple major release lines which are compatible with Silverstripe CMS 4. If you use either of these modules, you should upgrade to the latest CMS 4 compatible version _before_ upgrading to CMS 5.
+
+- [Upgrade guide for `silverstripe/graphql`](https://docs.silverstripe.org/en/4/upgrading/upgrading_to_graphql_4)
+- [Upgrade guide for `tractorcow/silverstripe-fluent`](https://docs.silverstripe.org/en/4/upgrading/upgrading_fluent)
 
 ### Modules not supported going forward
 Some modules that were commercially supported in Silverstripe CMS 4 will not be supported in Silverstripe CMS 5. Some of those modules will provide CMS5-compatible versions. Others will be dropped altogether.
@@ -1661,6 +1669,11 @@ This is a major release and contains many breaking API changes. Deprecation warn
 - Changed return type for [`Symbiote\QueuedJobs\Services\QueuedJobHandler::handleBatch()`](api:Symbiote\QueuedJobs\Services\QueuedJobHandler::handleBatch()) from dynamic to `void`
 - Changed return type for [`Symbiote\QueuedJobs\Services\QueuedJobHandler::write()`](api:Symbiote\QueuedJobs\Services\QueuedJobHandler::write()) from dynamic to `void`
 - Changed parameter type in [`Symbiote\QueuedJobs\Services\QueuedJobHandler::write()`](api:Symbiote\QueuedJobs\Services\QueuedJobHandler::write()) for `$record` from `array` to `Monolog\LogRecord`
+
+#### tractorcow/silverstripe-fluent
+
+- Removed deprecated method `TractorCow\Fluent\Extension\FluentExtension::getLinkingMode()`
+- Removed deprecated method `TractorCow\Fluent\Extension\FluentExtension::LocaleLink()`
 
 <!--- Changes below this line will be automatically regenerated -->
 


### PR DESCRIPTION
Description from parent issue (since it's private):
> Acceptance criteria
> - The Guide should explain how to upgrade from Fluent v4 to Fluent v6/v7.
> - The Guide should explain how to upgrade from Fluent v5 to Fluent v6/v7.
>
> Notes
>
> - If you are on Fluent v4, we are not sure if the best course of action is to skip 5 and go straight to 6. The person who picks up this card should spend some time analysing what the best approach is on in this case and draft the guide accordingly.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/662