### PR TITLE
DOC Update Getting Started and ORM sections

### DIFF
--- a/en/00_Getting_Started/03_Environment_Management.md
+++ b/en/00_Getting_Started/03_Environment_Management.md
@@ -35,9 +35,14 @@ not be detected automatically. If you wish to load environment variables from a 
 need to do so manually. See the [Including an extra `.env` file](#including-an-extra-env-file) section below for more
 information.
 
-## Managing environment variables with Apache
+## Other ways to manage environment variables
 
-You can set "real" environment variables using Apache. Please
+Silverstripe CMS will respect environment variables provided by the server.
+
+If you are using a docker compose setup, you can set environment variables in your `docker-compose.yml` file.
+[See the docker compose docs for more information](https://docs.docker.com/compose/compose-file/#environment).
+
+You can set environment variables using Apache. Please
 [see the Apache docs for more information](https://httpd.apache.org/docs/current/env.html).
 
 ## How to access the environment variables
@@ -48,6 +53,12 @@ Accessing the environment variables should be done via the [`Environment::getEnv
 use SilverStripe\Core\Environment;
 Environment::getEnv('SS_DATABASE_CLASS');
 ```
+
+[hint]
+The `Environment::getEnv()` method will return `false` both if there was no value set for a variable or if
+the variable was explicitly set as `false`. You can determine whether a variable has been set by calling
+[`Environment::hasEnv()`](api:SilverStripe\Core\Environment::hasEnv()).
+[/hint]
 
 Individual settings can be assigned via [`Environment::setEnv()`](api:SilverStripe\Core\Environment::setEnv()) or [`Environment::putEnv()`](api:SilverStripe\Core\Environment::putEnv()) methods.
 
@@ -74,16 +85,16 @@ SilverStripe\Core\Injector\Injector:
             ThisWillNotSubstitute: 'lorem `REGULAR_TEXT` ipsum'
 ```
 
-[info]
+[warning]
 Environment variables cannot be used outside of Injector config.
-[/info]
+[/warning]
 
 ## Including an extra .env file
 
 Sometimes it may be useful to include an extra `.env` file - on a shared local development environment where all
 database credentials could be the same. To do this, you can add this snippet to your `app/_config.php` file:
 
-Note that by default variables cannot be overloaded from this file; Existing values will be preferred over values in
+Note that by default variables cannot be overridden from this file; Existing values will be preferred over values in
 this file.
 
 ```php
@@ -93,40 +104,42 @@ $loader = new EnvironmentLoader();
 $loader->loadFile($env);
 ```
 
+[warning]
+Note that because `_config.php` is processed after yaml configuration, variables set in these extra `.env` files cannot be used inside yaml config.
+[/warning]
+
 ## Core environment variables
 
 Silverstripe core environment variables are listed here, though you're free to define any you need for your application.
 
 | Name  | Description |
 | ----  | ----------- |
-| `SS_DATABASE_CLASS` | The database class to use, MySQLDatabase, MSSQLDatabase, etc. defaults to MySQLDatabase.|
-| `SS_DATABASE_SERVER`| The database server to use, defaulting to localhost.|
+| `SS_DATABASE_CLASS` | The database class to use. Only `MySQLDatabase` is included by default, but other values are available in optional modules such as [`PostgreSQLDatabase`](https://github.com/silverstripe/silverstripe-postgresql). Defaults to `MySQLDatabase`.|
+| `SS_DATABASE_SERVER`| The database server to use. Defaults to `localhost`.|
 | `SS_DATABASE_USERNAME`| The database username (mandatory).|
 | `SS_DATABASE_PASSWORD`| The database password (mandatory).|
 | `SS_DATABASE_PORT`|     The database port.|
 | `SS_DATABASE_SUFFIX`|   A suffix to add to the database name.|
 | `SS_DATABASE_PREFIX`|   A prefix to add to the database name.|
+| `SS_DATABASE_NAME` | The database name. If not set, `SS_DATABASE_CHOOSE_NAME` must be set instead. |
+| `SS_DATABASE_CHOOSE_NAME`| Boolean/Int. If defined, then the system will choose a default database name for you. The database name will be "SS_" followed by the name of the folder into which you have installed Silverstripe.<br />If `SS_DATABASE_CHOOSE_NAME` is an integer greater than one, then an ancestor folder will be used for the  database name. This is handy for a site that's hosted from `/sites/examplesite/www` or `/buildbot/allmodules-2.3/build`. If it's `2`, the parent folder will be chosen; if it's `3` the grandparent, and so on.<br /><br />Ignored if `SS_DATABASE_NAME` is set.|
 | `SS_DATABASE_TIMEZONE`| Set the database timezone to something other than the system timezone.
-| `SS_DATABASE_NAME` | Set the database name. Assumes the `$database` global variable in your config is missing or empty. |
-| `SS_DATABASE_CHOOSE_NAME`| Boolean/Int. If defined, then the system will choose a default database name for you if one isn't give in the $database variable. The database name will be "SS_" followed by the name of the folder into which you have installed Silverstripe. If this is enabled, it means that the phpinstaller will work out of the box without the installer needing to alter any files. This helps prevent accidental changes to the environment. If `SS_DATABASE_CHOOSE_NAME` is an integer greater than one, then an ancestor folder will be used for the  database name. This is handy for a site that's hosted from /sites/examplesite/www or /buildbot/allmodules-2.3/build. If it's 2, the parent folder will be chosen; if it's 3 the grandparent, and so on.|
-| `SS_DEPRECATION_ENABLED` | Enable deprecation notices for this environment. `SS_ENVIRONMENT_TYPE` must be set to `dev` for deprecation notices to show. |
-| `SS_ENVIRONMENT_TYPE`| The environment type: dev, test or live.|
-| `SS_DEFAULT_ADMIN_USERNAME`| The username of the default admin. This is a user with administrative privileges.|
-| `SS_DEFAULT_ADMIN_PASSWORD`| The password of the default admin. This will not be stored in the database.|
-| `SS_USE_BASIC_AUTH`| Baseline protection for requests handled by Silverstripe. Usually requires additional security measures for comprehensive protection. See [Environment Types](/developer_guides/debugging/environment_types) for caveats.|
-| `SS_SEND_ALL_EMAILS_TO`| If you define this constant, all emails will be redirected to this address.|
-| `SS_SEND_ALL_EMAILS_FROM`| If you define this constant, all emails will be sent from this address.|
-| `SS_ERROR_LOG` | Relative path to the log file. |
-| `SS_PROTECTED_ASSETS_PATH` | Path to secured assets - defaults to ASSETS_PATH/.protected |
-| `SS_DATABASE_MEMORY` | Used for SQLite3 DBs |
-| `SS_TRUSTED_PROXY_IPS` | IP address or CIDR range to trust proxy headers from. If left blank no proxy headers are trusted. Can be set to 'none' (trust none) or '*' (trust all) |
-| `SS_ALLOWED_HOSTS` | A comma deliminated list of hostnames the site is allowed to respond to |
-| `SS_MANIFESTCACHE` | The manifest cache to use (defaults to file based caching). Must be a `Psr\Cache\CacheItemPoolInterface`, `Psr\SimpleCache\CacheInterface`, or `SilverStripe\Core\Cache\CacheFactory` class implementation |
-| `SS_IGNORE_DOT_ENV` | If set the .env file will be ignored. This is good for live to mitigate any performance implications of loading the .env file |
-| `SS_BASE_URL` | The url to use when it isn't determinable by other means (eg: for CLI commands) |
-| `SS_DATABASE_SSL_KEY` | Absolute path to SSL key file |
-| `SS_DATABASE_SSL_CERT` | Absolute path to SSL certificate file |
-| `SS_DATABASE_SSL_CA` | Absolute path to SSL Certificate Authority bundle file |
-| `SS_DATABASE_SSL_CIPHER` | Optional setting for custom SSL cipher |
-| `SS_FLUSH_ON_DEPLOY` | Try to detect deployments through file system modifications and flush on the first request after every deploy. Does not run "dev/build", but only "flush". Possible values are `true` (check for a framework PHP file modification time), `false` (no checks, skip deploy detection) or a path to a specific file or folder to be checked. See [DeployFlushDiscoverer](api:SilverStripe\Core\Startup\DeployFlushDiscoverer) for more details.<br /><br />False by default. |
-| `SS_TEMP_PATH` | File storage used for the default cache adapters in [Manifests](/developer_guides/execution_pipeline/manifests), [Object Caching](/developer_guides/performance/caching) and [Partial Template Caching](/developer_guides/templates/partial_template_caching). It defaults to creating a sub-directory of PHP's built-in `sys_get_temp_dir()`. Can be an absolute path (with a leading `/`), or a path relative to the project root. |
+| `SS_DEPRECATION_ENABLED` | Enable deprecation notices for this environment. `SS_ENVIRONMENT_TYPE` must be set to `dev` for deprecation notices to show. See [Deprecations](/upgrading/deprecations/) for more information. |
+| `SS_DEPRECATION_SHOW_HTTP` | Include deprecation warnings in HTTP responses if `SS_ENVIRONMENT_TYPE` is true. Defaults to false. |
+| `SS_DEPRECATION_SHOW_CLI` | Include deprecation warnings in CLI responses if `SS_ENVIRONMENT_TYPE` is true. Defaults to true. |
+| `SS_ENVIRONMENT_TYPE`| The environment type. Should be one of `dev`, `test`, or `live`. See [Environment Types](/debugging/environment_types/) for more information. |
+| `SS_DEFAULT_ADMIN_USERNAME`| The username of the default admin. This is a user with administrative privileges. |
+| `SS_DEFAULT_ADMIN_PASSWORD`| The password of the default admin. This will not be stored in the database. |
+| `SS_USE_BASIC_AUTH`| Baseline protection for requests handled by Silverstripe. Usually requires additional security measures for comprehensive protection. Set this to the name of a permission which users must have to be able to access the site (e.g. "ADMIN"). See [Environment Types](/developer_guides/debugging/environment_types) for caveats. |
+| `SS_SEND_ALL_EMAILS_TO`| If you define this constant all emails will be redirected to this address, overriding the original address(es). |
+| `SS_SEND_ALL_EMAILS_FROM`| If you define this constant all emails will be sent from this address, overriding the original address. |
+| `SS_ERROR_LOG` | Path to a file for logging errors, relative to the project root. See [Logging and Error Handling](/developer_guides/debugging/error_handling/) for more information about error logging. |
+| `SS_PROTECTED_ASSETS_PATH` | Path to secured assets - defaults to `ASSETS_PATH/.protected`. See [Protected file paths](/developer_guides/files/file_storage/#protected-file-paths) for more information. |
+| `SS_DATABASE_MEMORY` | Used for [SQLite3](https://github.com/silverstripe/silverstripe-sqlite3) database connectors. |
+| `SS_TRUSTED_PROXY_IPS` | IP address or CIDR range to trust proxy headers from. If left blank no proxy headers are trusted. Can be set to 'none' (trust none) or '*' (trust all). See [Request hostname forgery](/developer_guides/security/secure_coding/#request-hostname-forgery) for more information. |
+| `SS_ALLOWED_HOSTS` | A comma deliminated list of hostnames the site is allowed to respond to. See [Request hostname forgery](/developer_guides/security/secure_coding/#request-hostname-forgery) for more information. |
+| `SS_MANIFESTCACHE` | The manifest cache to use (defaults to file based caching). Must be a `Psr\Cache\CacheItemPoolInterface`, `Psr\SimpleCache\CacheInterface`, or `SilverStripe\Core\Cache\CacheFactory` class implementation. |
+| `SS_IGNORE_DOT_ENV` | If set, the `.env` file will be ignored. This is good for live to mitigate any performance implications of loading the `.env` file. |
+| `SS_BASE_URL` | The url to use when it isn't determinable by other means (eg: for CLI commands). Should either start with a protocol (e.g. `https://www.example.com`) or with a double forward slash (e.g. `//www.example.com`). |
+| `SS_FLUSH_ON_DEPLOY` | Try to detect deployments through file system modifications and flush on the first request after every deploy. Does not run "dev/build" - only "flush". Possible values are `true` (check for a framework PHP file modification time), `false` (no checks, skip deploy detection) or a path to a specific file or folder to be checked. See [DeployFlushDiscoverer](api:SilverStripe\Core\Startup\DeployFlushDiscoverer) for more details.<br /><br />False by default. |
+| `SS_TEMP_PATH` | File storage used for the default cache adapters in [Manifests](/developer_guides/execution_pipeline/manifests), [Object Caching](/developer_guides/performance/caching) and [Partial Template Caching](/developer_guides/templates/partial_template_caching). Can be an absolute path (with a leading `/`), or a path relative to the project root. Defaults to creating a sub-directory of PHP's built-in `sys_get_temp_dir()` or using the `silverstripe-cache` directory relative to the project root if one is present. |

--- a/en/00_Getting_Started/04_Directory_Structure.md
+++ b/en/00_Getting_Started/04_Directory_Structure.md
@@ -18,8 +18,8 @@ Directory            | Description
 `public/`            | Webserver public webroot
 `public/assets/`     | Images and other files uploaded via the Silverstripe CMS. You can also place your own content inside it, and link to it from within the content area of the CMS.
 `public/assets/.protected/` | Default location for [protected assets](/developer_guides/files/file_security)
-`public/_resources/` | Exposed public files added from modules. Folders within this parent will match that of the source root location (this can be altered by configuration).
-`vendor/`            | Silverstripe modules and other supporting libraries (the framework is in `vendor/silverstripe/framework`)
+`public/_resources/` | Exposed public files added from modules. Folders within this parent will match that of the source root location ([this can be altered by configuration](/developer_guides/templates/requirements/#configuring-your-project-exposed-folders)).
+`vendor/`            | Silverstripe modules and other supporting libraries (e.g. the framework is in `vendor/silverstripe/framework`)
 `themes/`            | Standard theme installation location
 
 ## Custom Code Structure
@@ -27,22 +27,22 @@ Directory            | Description
 We use `app/` as the default folder.
 
 | Directory             | Description                                                         |
- | ---------             | -----------                                                         |
+| ---------             | -----------                                                         |
 | `app/`           | This directory contains all of your code that defines your website. |
-| `app/_config`    | YAML configuration specific to  your application                    |
-| `app/src`        | PHP code for model and controller (subdirectories are optional)     |
-| `app/tests`      | PHP Unit tests                                                      |
-| `app/templates`  | HTML [templates](/developer_guides/templates) with *.ss-extension for the `$default` theme   |
-| `app/css `       | CSS files                                                           |
-| `app/images `    | Images used in the HTML templates                                   |
-| `app/javascript` | Javascript and other script files                                   |
-| `app/client`     | More complex projects can alternatively contain frontend assets in a common `client` folder |
+| `app/_config`    | YAML configuration specific to your application                    |
+| `app/src`        | PHP code specific to your application (subdirectories are optional)     |
+| `app/tests`      | PHP unit/functional/end-to-end tests                                                      |
+| `app/templates`  | HTML [templates](/developer_guides/templates) with `*.ss-extension` for the `$default` theme   |
+| `app/client/src` | Conventional directory for source resources (images/css/javascript) for your CMS customisations |
+| `app/client/dist` | Conventional directory for transpiled resources (images/css/javascript) for your CMS customisations |
+| `app/client/lang` | Conventional directory for [javascript translation tables](/developer_guides/i18n/#translation-tables-in-javascript) |
+| `app/lang` | Contains [yaml translation tables](/developer_guides/i18n/#language-definitions) |
 | `app/themes/<yourtheme>` | Custom nested themes (note: theme structure is described below)     |
 
 Arbitrary directory-names are allowed, as long as they don't collide with existing modules or the directories lists in
 "Core Structure". Here's how you would reconfigure your default folder to `myspecialapp`.
 
-*myspecialapp/_config/config.yml*
+**`myspecialapp/_config/config.yml`**
 
 ```yml
 ---
@@ -52,13 +52,13 @@ SilverStripe\Core\Manifest\ModuleManifest:
     project: 'myspecialapp'
 ```
 
-Check our [JavaScript Coding Conventions](javascript_coding_conventions) for more details on folder and file naming in
+Check our [JavaScript Coding Conventions](/contributing/javascript_coding_conventions/) for more details on folder and file naming in
 Silverstripe core modules.
 
 ## Themes Structure
 
 | Directory                       | Description                                                     |
- | ------------------              | ---------------------------                                     |
+| ------------------              | ---------------------------                                     |
 | `themes/simple/`                | Standard "simple" theme                                         |
 | `themes/<yourtheme>/`           | Custom theme base directory                                     |
 | `themes/<yourtheme>/templates`  | Theme templates                                                 |
@@ -66,34 +66,35 @@ Silverstripe core modules.
 
 See [themes](/developer_guides/templates/themes).
 
-## Module Structure {#module_structure}
+## Module Structure
 
 Modules are commonly stored as composer packages in the `vendor/` folder. They need to have a `_config.php` file or
 a `_config/` directory present, and should follow the same conventions as posed in "Custom Site Structure".
 
-Example Forum:
+Example for the [silverstripe/blog](https://github.com/silverstripe/silverstripe-blog) module:
 
 | Directory  | Description                                                         |
- | ---------  | -----------                                                         |
-| `vendor/silverstripe/blog/`| This directory contains all of your code that defines your website. |
-| `vendor/silverstripe/blog/code` | PHP code for model and controller (subdirectories are optional)     |
+| ---------  | -----------                                                         |
+| `vendor/silverstripe/blog/` | This directory contains all of your code that defines the module. |
+| `vendor/silverstripe/_config` | YAML configuration specific to the module                    |
+| `vendor/silverstripe/blog/src` | PHP code specific to the module (subdirectories are optional)     |
 | ...        | ...                                                                 |
 
 ### Module documentation
 
-Module developers can bundle developer documentation with their code by producing plain text files inside a 'docs'
+Module developers can bundle developer documentation with their code by producing plain text files inside a `docs/`
 folder located in the module folder. These files can be written with the Markdown syntax
 (see [Contributing Documentation](/contributing/documentation))
 and include media such as images or videos.
 
 Inside the `docs/` folder, developers should organise the markdown files into each separate language they wish to write
-documentation for (usually just `en`). Inside each languages' subfolder, developers then have freedom to create whatever
+documentation for (e.g. `en` for english documentation). Inside each languages' subfolder, developers then have freedom to create whatever
 structure they wish for organising the documentation they wish.
 
 Example Blog Documentation:
 
 | Directory  | Description                                                         |
- | ---------  | -----------                                                         |
+| ---------  | -----------                                                         |
 | `vendor/silverstripe/blog/docs` | |
 | `vendor/silverstripe/blog/docs/_manifest_exclude` | Empty file to signify that Silverstripe does not need to load classes from this folder |
 | `vendor/silverstripe/blog/docs/en/`       | English documentation  |
@@ -101,7 +102,7 @@ Example Blog Documentation:
 | `vendor/silverstripe/blog/docs/en/Getting_Started.md` | Documentation page. Naming convention is Uppercase and underscores. |
 | `vendor/silverstripe/blog/docs/en/_images/` | Folder to store any images or media |
 | `vendor/silverstripe/blog/docs/en/Some_Topic/` | You can organise documentation into nested folders. Naming convention is Uppercase and underscores. |
-| `vendor/silverstripe/blog/docs/en/04_Some_Topic/00_Getting_Started.md`|Structure is created by use of numbered prefixes. This applies to nested folders and documentations pages, index.md should not have a prefix.|
+| `vendor/silverstripe/blog/docs/en/04_Some_Topic/00_Getting_Started.md`|Structure is created by use of numbered prefixes. This applies to nested folders and documentations pages, `index.md` should not have a prefix.|
 
 ## Autoloading
 

--- a/en/00_Getting_Started/05_Recipes.md
+++ b/en/00_Getting_Started/05_Recipes.md
@@ -23,12 +23,12 @@ Silverstripe CMS is powered by a system of components in the form of Composer pa
 
 By design, modules tend to be small and serve a specific function. You may need to combine many modules to achieve a wider goal. 
 
-For example, the `silverstripe/blog` module by itself simply allows you to create blog posts. It does not include all the features you could want in a blog, like a comment system or widgets to display related content.
+For example, the [`silverstripe/blog`](https://github.com/silverstripe/silverstripe-blog) module by itself simply allows you to create blog posts. It does not include all the features you could want in a blog, like a comment system or widgets to display related content.
 
-The `silverstripe/recipe-blog` recipe installs `silverstripe/blog` module, but also:
-- `silverstripe/widgets` and `silverstripe/content-widget` to display widgets
-- `silverstripe/comments` and `silverstripe/comment-notifications` to allow the management of comments on blog post
-- `silverstripe/spamprotection` and `silverstripe/akismet` to provide basic SPAM protection on comments.
+The [`silverstripe/recipe-blog`](https://github.com/silverstripe/recipe-blog) recipe installs `silverstripe/blog` module, but also:
+- [`silverstripe/widgets`](https://github.com/silverstripe/silverstripe-widgets) and [`silverstripe/content-widget`](https://github.com/silverstripe/silverstripe-content-widget) to display widgets
+- [`silverstripe/comments`](https://github.com/silverstripe/silverstripe-comments) and [`silverstripe/comment-notifications`](https://github.com/silverstripe/comment-notifications) to allow the management of comments on blog post
+- [`silverstripe/spamprotection`](https://github.com/silverstripe/silverstripe-spamprotection) to provide basic SPAM protection on comments.
 
 ## Finding recipes for Silverstripe CMS
 
@@ -38,7 +38,7 @@ The Silverstripe CMS project maintains a number of recipes. Some third parties a
 
 ## Releasing supported recipes
 
-When we announce a new release of Silverstripe CMS and publish a changelog for it, we refer to a new set of _Recipe_ versions, which include new versions of some or all of their associated Modules. The easiest way to keep up to date with new Silverstripe CMS releases is to depend on one of the core Recipes:
+When we announce a new release of Silverstripe CMS and publish a changelog for it, we refer to a new set of _recipe_ versions, which include new versions of some or all of their associated Modules. The easiest way to keep up to date with new Silverstripe CMS releases is to depend on one of the core Recipes:
 
 - [`silverstripe/recipe-core`](https://packagist.org/packages/silverstripe/recipe-core): Contains only the base
   framework, without the admin UI or CMS features.

--- a/en/00_Getting_Started/index.md
+++ b/en/00_Getting_Started/index.md
@@ -6,7 +6,7 @@ icon: rocket
 
 ## Server Requirements
 
-Silverstripe requires PHP 7.1 or newer. It runs on many webservers and databases, but is most commonly served using
+Silverstripe requires PHP 8.1 or newer. It runs on many webservers and databases, but is most commonly served using
 Apache and MySQL/MariaDB.
 
 If you are setting up your own environment, you'll need to consider a few configuration settings such as URL rewriting
@@ -19,16 +19,21 @@ started. Silverstripe is installed via [Composer](https://getcomposer.org), a pa
 you install and upgrade the framework and other modules. Assuming you've got this tool, run the following command to
 install Silverstripe:
 
-```
+```bash
 composer create-project silverstripe/installer my-project
 ```
 
 Within the newly created `my-project` folder, point your webserver at the `public/` folder.
 
-Now create a `.env` file your project root (not the `public/` folder). It sets up the minimum
-required [environment variables](environment_management). Replace the placeholders as required:
+Now create a `.env` file in your project root (not the `public/` folder).
 
-```
+[hint]
+If you used `silverstripe/installer` to create your project, you can rename the `.env.example` file to `.env`. It includes the minimum required [environment variables](environment_management).
+[/hint]
+
+Replace the placeholders as required:
+
+```bash
 SS_DATABASE_CLASS="MySQLDatabase"
 SS_DATABASE_NAME="<database>"
 SS_DATABASE_SERVER="localhost"
@@ -41,7 +46,7 @@ SS_ENVIRONMENT_TYPE="<dev|test|live>"
 
 Now you should be able to build your database by running this command:
 
-```
+```bash
 vendor/bin/sake dev/build
 ```
 
@@ -64,4 +69,3 @@ Webserver setup is covered in
 
 If you run into trouble, see [the Tips & Tricks forum](https://forum.silverstripe.org/c/tips) or get help on
 our [Slack channel](https://www.silverstripe.org/community/slack-signup/).
-

--- a/en/02_Developer_Guides/00_Model/01_Data_Model_and_ORM.md
+++ b/en/02_Developer_Guides/00_Model/01_Data_Model_and_ORM.md
@@ -6,7 +6,7 @@ icon: database
 
 # Introduction to the Data Model and ORM
 
-Silverstripe uses an [object-relational mapping](https://en.wikipedia.org/wiki/Object-relational_mapping) to represent its
+Silverstripe uses an [object-relational mapping](https://en.wikipedia.org/wiki/Object-relational_mapping) (aka "ORM") to represent its
 information.
 
 *  Each database table maps to a PHP class.
@@ -27,11 +27,14 @@ use SilverStripe\ORM\DataObject;
 
 class Player extends DataObject 
 {
+    private static $table_name = 'Player';
+
     private static $db = [
         'PlayerNumber' => 'Int',
         'FirstName' => 'Varchar(255)',
         'LastName' => 'Text',
-        'Birthday' => 'Date'
+        'Birthday' => 'Date',
+        'Status' => 'Varchar(255)',
     ];
 }
 ```
@@ -39,14 +42,20 @@ class Player extends DataObject
 This `Player` class definition will create a database table `Player` with columns for `PlayerNumber`, `FirstName` and
 so on. After writing this class, we need to regenerate the database schema.
 
+[hint]
+You can technically omit the `table_name` property, and a default table name will be created based on the fully qualified class name - but this can result in table names that are too long for the database engine to handle. We recommend that you _always_ explicitly declare a table name for your models.
+
+See more in [Mapping classes to tables with `DataObjectSchema`](#mapping-classes-to-tables) below.
+[/hint]
+
 ## Generating the Database Schema
 
 After adding, modifying or removing `DataObject` subclasses, make sure to rebuild your Silverstripe CMS database. The
-database schema is generated automatically by visiting the `/dev/build` (e.g. `https://www.example.com/dev/build`) in your browser
-while authenticated as an administrator.
+database schema is generated automatically by visiting `/dev/build` (e.g. `https://www.example.com/dev/build`) in your browser
+while authenticated as an administrator, or by running `sake dev/build` on the command line (see [Command Line Interface](/developer_guides/cli/) to learn more about `sake`).
 
 [info]
-In dev mode, you do not need to be authenticated to build the database by visiting the `/dev/build` route.
+In "dev" mode, you do not need to be authenticated to run `/dev/build`. See [Environment Types](/developer_guides/debugging/environment_types) for more information.
 [/info]
 
 This script will analyze the existing schema, compare it to what's required by your data classes, and alter the schema
@@ -55,49 +64,28 @@ as required.
 It will perform the following changes:
 
 * Create any missing tables
-* Create any missing fields
+* Create any missing field columns
 * Create any missing indexes
 * Alter the field type of any existing fields
-* Rename any obsolete tables that it previously created to _obsolete_(tablename)
+* Rename any obsolete tables that it previously created to `_obsolete_tablename` (e.g. `_obsolete_player`)
+  * Obsolete tables are only renamed if the `DataObject` model which owns the table has no need for the table (e.g. no fields are declared for the model, and it is a subclass of some other `DataObject`).
 
 It **won't** do any of the following
 
 * Delete tables
-* Delete fields
+* Delete field columns
 * Rename any tables that it doesn't recognize. This allows other applications to coexist in the same database, as long as
   their table names don't match a Silverstripe CMS data class.
 
-
-[notice]
-You need to be logged in as an administrator to perform this command, unless your site is in [dev mode](../debugging),
-or the command is run through [CLI](../cli).
-[/notice]
-
-When rebuilding the database schema through the [ClassLoader](api:SilverStripe\Core\Manifest\ClassLoader) the following additional properties are
+When rebuilding the database schema through the [ClassLoader](api:SilverStripe\Core\Manifest\ClassLoader) the following additional fields are
 automatically set on the `DataObject`.
 
-*  ID: Primary Key. This will use the database's built-in auto-numbering system on the base table, and apply the same ID to all subclass tables.
-*  ClassName: An enumeration listing this data-class and all of its subclasses.
-*  Created: A date/time field set to the creation date of this record
-*  LastEdited: A date/time field set to the date this record was last edited through `write()`
+*  `ID`: Primary Key. This will use the database's built-in auto-numbering system on the base table, and apply the same ID to all subclass tables.
+*  `ClassName`: An enumeration listing this data-class and all of its subclasses. The value is the actual `DataObject` subclass used to write the record.
+*  `Created`: A date/time field set to the creation date (i.e. when it was first written to the database) of this record
+*  `LastEdited`: A date/time field set to the date this record was last edited through `write()`
 
-**app/src/Player.php**
-
-```php
-use SilverStripe\ORM\DataObject;
-
-class Player extends DataObject 
-{
-    private static $db = [
-        'PlayerNumber' => 'Int',
-        'FirstName' => 'Varchar(255)',
-        'LastName' => 'Text',
-        'Birthday' => 'Date'
-    ];
-}
-```
-
-Generates the following `SQL`.
+The table creation SQL statement for our `Player` model above looks like this:
 
 ```sql
 CREATE TABLE `Player` (
@@ -109,6 +97,7 @@ CREATE TABLE `Player` (
     `FirstName` varchar(255) DEFAULT NULL,
     `LastName` mediumtext,
     `Birthday` datetime DEFAULT NULL,
+    `Status` varchar(255) DEFAULT NULL,
 
     PRIMARY KEY (`ID`),
     KEY `ClassName` (`ClassName`)
@@ -117,24 +106,25 @@ CREATE TABLE `Player` (
 
 ## Creating Data Records
 
-A new instance of a [DataObject](api:SilverStripe\ORM\DataObject) can be created using the `new` syntax.
+A new instance of a [DataObject](api:SilverStripe\ORM\DataObject) can be created using the `new` keyword.
 
 ```php
 $player = new Player();
 ```
 
-Or, a better way is to use the `create` method.
+However, a better way is to use the `create()` method.
 
 ```php
 $player = Player::create();
 ```
 
-[notice]
-Using the `create()` method provides chainability, which can add elegance and brevity to your code, e.g. `Player::create()->write()`. More importantly, however, it will look up the class in the [Injector](../extending/injector) so that the class can be overridden by [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection).
-[/notice]
+[hint]
+Using the `create()` method provides chainability (known as a "fluent API" or "[fluent interface](https://en.wikipedia.org/wiki/Fluent_interface)"), which can add elegance and brevity to your code, e.g. `Player::create(['FirstName' => 'Sam'])->write()`.
 
+More importantly, however, it will look up the class in the [Injector](api:SilverStripe\Core\Injector\Injector) so that the class can be overridden by [dependency injection](../extending/injector). For this reason, instantiating records using the `new` keyword is considered bad practice.
+[/hint]
 
-Database columns and properties can be set as class properties on the object. The Silverstripe CMS ORM handles the saving
+Database columns (aka fields) can be set as class properties on the object. The Silverstripe CMS ORM handles the saving
 of the values through a custom `__set()` method.
 
 ```php
@@ -158,48 +148,75 @@ $id = $player->write();
 
 ## Querying Data
 
-With the `Player` class defined we can query our data using the `ORM` or Object-Relational Model. The `ORM` provides
+With the `Player` class defined we can query our data using the ORM. The ORM provides
 shortcuts and methods for fetching, sorting and filtering data from our database.
 
 ```php
-$players = Player::get();
 // returns a `DataList` containing all the `Player` objects.
+$players = Player::get();
 
+// returns the first and last `Player` record in the list, respectively.
+$firstPlayer = $players->first();
+$lastPlayer = $players->last();
+
+// returns a single `Player` record that has the ID of 2.
 $player = Player::get()->byID(2);
-// returns a single `Player` object instance that has the ID of 2.
-
-echo $player->ID;
-// returns the players 'ID' column value
-
-echo $player->dbObject('LastEdited')->Ago();
-// calls the `Ago` method on the `LastEdited` property.
+$player = Playet::get_by_id(2);
 ```
 
-The `ORM` uses a "fluent" syntax, where you specify a query by chaining together different methods.  Two common methods
+[hint]
+All of the above methods to get a single record will return `null` if there is no record to return.
+[/hint]
+
+[info]
+`DataObject::get()->byID()` and `DataObject::get_by_id()` achieve similar results, though the object returned by `DataObject::get_by_id()` is cached against a `static` property within `DataObject`.
+[/info]
+
+The ORM uses a "fluent" syntax, where you specify a query by chaining together different methods.  Two common methods
 are `filter()` and `sort()`:
 
 ```php
-$members = Player::get()->filter([
-    'FirstName' => 'Sam'
-])->sort('Surname');
-
 // returns a `DataList` containing all the `Player` records that have the `FirstName` of 'Sam'
-
+$members = Player::get()->filter([
+    'FirstName' => 'Sam',
+])->sort('Surname');
 ```
 
-[info]
-Provided `filter` values are automatically escaped and do not require any escaping.
-[/info]
+There's a lot more to filtering and sorting, so make sure to keep reading.
 
 [info]
-`DataObject::get()->byID()` and `DataObject::get_by_id()` achieve similar results, but the object returned by `DataObject::get_by_id()` is cached against a `static` property within `DataObject`.
-
-`DataObject::get_by_id()` is a legacy ORM method, and it is recommended that you use `DataObject::get()->byID()` wherever possible
+Values passed in to the `filter()` and `sort()` methods are automatically escaped and do not require any additional escaping. This makes it easy to safely filter/sort records by user input.
 [/info]
+
+### Querying data when you have a record
+
+When you have a `DataObject` record, it already has all of its database field data attached to it. You can get those values without triggering further database queries.
+
+[notice]
+This does not apply to relations, which are always lazy loaded. See the [Relations between Records](relations) documentation for more information.
+[/notice]
+
+```php
+$player = Player::get()->byID(2);
+
+// returns the players' `ID` field value
+$id = $player->ID;
+
+// gets the `LastEdited` field value in its default format
+$lastEdited = $player->LastEdited;
+// calls the `Ago` method on the `LastEdited` field.
+$timeSinceLastEdit = $player->dbObject('LastEdited')->Ago();
+```
+
+All database fields have a default value format which you can retrieve by treating the field as a class property - but there are also other formats available depending on the field type. You'll learn more about those in the [Data Types and Casting](data_types_and_casting) section - but the important thing to know is that you can get the `DBField` instance for a field by calling `dbObject('FieldName')` on the record - and that `DBField` instance will have different methods on it depending on the data type that let you access different formats of the field's value.
 
 ## Lazy Loading
 
-The `ORM` doesn't actually execute the [SQLSelect](api:SilverStripe\ORM\Queries\SQLSelect) until you iterate on the result with a `foreach()` or `<% loop %>`.
+The ORM doesn't actually execute the [SQLSelect](api:SilverStripe\ORM\Queries\SQLSelect) query until you iterate on the result (e.g. with a `foreach()` or `<% loop %>`).
+
+[hint]
+Some convenience methods (e.g. [`column()`](api:SilverStripe\ORM\DataList::column()) or aggregator methods like [`min()`](api:SilverStripe\ORM\DataList::min())) will also execute the query.
+[/hint]
 
 It's smart enough to generate a single efficient query at the last moment in time without needing to post-process the
 result set in PHP. In `MySQL` the query generated by the ORM may look something like this
@@ -229,7 +246,7 @@ echo $players->Count();
 
 ## Looping over a list of objects
 
-`get()` returns a `DataList` instance. You can loop over `DataList` instances in both PHP and templates.
+[`get()`](api:SilverStripe\ORM\DataObject::get()) returns a [`DataList`](api:SilverStripe\ORM\DataList) instance. You can loop over `DataList` instances in both PHP and templates.
 
 ```php
 $players = Player::get();
@@ -239,35 +256,21 @@ foreach($players as $player) {
 }
 ```
 
-Notice that we can step into the loop safely without having to check if `$players` exists. The `get()` call is robust, and will at worst return an empty `DataList` object. If you do want to check if the query returned any records, you can use the `exists()` method, e.g.
+Notice that we can step into the loop safely without having to check if `$players` exists. The `get()` call is robust, and will at worst return an empty `DataList` object. But if you do want to check if the query returned any records, you can use the `exists()` method, e.g.
 
 ```php
 $players = Player::get();
 
-if($players->exists()) {
+if ($players->exists()) {
     // do something here
 }
 ```
 
+[hint]
+While you could use `if ($players->Count() > 0)` for this condition, the `exists()` method uses an `EXISTS` SQL query, which is more performant.
+[/hint]
+
 See the [Lists](lists) documentation for more information on dealing with [SS_List](api:SilverStripe\ORM\SS_List) instances.
-
-## Returning a single DataObject
-
-There are a couple of ways of getting a single DataObject from the ORM. If you know the ID number of the object, you
-can use `byID($id)`:
-
-```php
-$player = Player::get()->byID(5);
-```
-
-`get()` returns a [DataList](api:SilverStripe\ORM\DataList) instance. You can use operations on that to get back a single record.
-
-```php
-$players = Player::get();
-
-$first = $players->first();
-$last = $players->last();
-```
 
 ## Sorting
 
@@ -296,7 +299,7 @@ However you might have several entries with the same `FirstName` and would like 
 ```php
 $players = Players::get()->sort([
     'FirstName' => 'ASC',
-    'LastName'=>'ASC'
+    'LastName' => 'ASC'
 ]);
 ```
 
@@ -304,8 +307,12 @@ You can also sort randomly. Using the `DB` class, you can get the random sort me
 
 ```php
 $random = DB::get_conn()->random(); 
-$players = Player::get()->sort($random);
+$players = Player::get()->orderBy($random);
 ```
+
+[warning]
+Note that we've used the `orderBy()` method here. This is because `sort()` doesn't allow sorting by raw SQL, which is necessary to use a random sort. Be careful whenever you use the `orderBy()` method to ensure you don't pass in any values you can't trust.
+[/warning]
 
 ## Filtering Results
 
@@ -313,45 +320,51 @@ The `filter()` method filters the list of objects that gets returned.
 
 ```php
 $players = Player::get()->filter([
-    'FirstName' => 'Sam'
+    'FirstName' => 'Sam',
 ]);
 ```
 
-Each element of the array specifies a filter.  You can specify as many filters as you like, and they **all** must be
+Each element of the array specifies a filter. You can specify as many filters as you like, and they **all** must be
 true for the record to be included in the result.
 
 The key in the filter corresponds to the field that you want to filter and the value in the filter corresponds to the
 value that you want to filter to.
 
-So, this would return only those players called "Sam Minnée".
+So, this would return only those players called "Sam Minnée":
 
 ```php
+// SELECT * FROM Player WHERE FirstName = 'Sam' AND LastName = 'Minnée'
 $players = Player::get()->filter([
     'FirstName' => 'Sam',
     'LastName' => 'Minnée',
 ]);
-
-// SELECT * FROM Player WHERE FirstName = 'Sam' AND LastName = 'Minnée'
 ```
 
-There is also a shorthand way of getting Players with the FirstName of Sam.
+There is also a shorthand way of getting Players with a specific value for any given field:
 
 ```php
 $players = Player::get()->filter('FirstName', 'Sam');
 ```
 
-Or if you want to find both Sam and Sig.
+Or if you want to find both Sam and Sig:
 
 ```php
-$players = Player::get()->filter(
-    'FirstName', ['Sam', 'Sig']
-);
-
 // SELECT * FROM Player WHERE FirstName IN ('Sam', 'Sig')
+$players = Player::get()->filter('FirstName', ['Sam', 'Sig']);
 ```
 
-You can use [SearchFilters](searchfilters) to add additional behavior to your `filter` command rather than an
-exact match.
+You can use an array of values when passing an array of filters in as the first argument as well, e.g:
+
+```php
+// SELECT * FROM Player WHERE FirstName = 'Sam' AND LastName in ('Minnée', 'Carter')
+$players = Player::get()->filter([
+    'FirstName' => 'Sam',
+    'LastName' => 'Minnée',
+]);
+```
+
+You can use a `SearchFilter` to add additional behavior to your `filter` command rather than an
+exact match. See [SearchFilter Modifiers](searchfilters) for more information.
 
 ```php
 $players = Player::get()->filter([
@@ -365,26 +378,25 @@ $players = Player::get()->filter([
 Use the `filterAny()` method to match multiple criteria non-exclusively (with an "OR" disjunctive),
 
 ```php
+// SELECT * FROM Player WHERE ("FirstName" = 'Sam' OR "Age" = '17')
 $players = Player::get()->filterAny([
     'FirstName' => 'Sam',
     'Age' => 17,
 ]);
-
-// SELECT * FROM Player WHERE ("FirstName" = 'Sam' OR "Age" = '17')
 ```
 
 You can combine both conjunctive ("AND") and disjunctive ("OR") statements.
 
 ```php
+// SELECT * FROM Player WHERE ("LastName" = 'Minnée' AND ("FirstName" = 'Sam' OR "Age" in ('17', '18')))
 $players = Player::get()
     ->filter([
         'LastName' => 'Minnée',
     ])
     ->filterAny([
         'FirstName' => 'Sam',
-        'Age' => 17,
+        'Age' => [17, 18],
     ]);
-// SELECT * FROM Player WHERE ("LastName" = 'Minnée' AND ("FirstName" = 'Sam' OR "Age" = '17'))
 ```
 
 You can use [SearchFilters](searchfilters) to add additional behavior to your `filterAny` command.
@@ -398,37 +410,34 @@ $players = Player::get()->filterAny([
 
 ### Filtering by null values
 
-Since null values in SQL are special, they are non-comparable with other values, certain filters will add
-`IS NULL` or `IS NOT NULL` predicates automatically to your query. As per ANSI SQL-92, any comparison
+Since null values in SQL are special, they are non-comparable with other values. Certain filters will add
+`IS NULL` or `IS NOT NULL` predicates automatically to your query. As per [ANSI SQL-92](https://en.wikipedia.org/wiki/SQL-92), any comparison
 condition against a field will filter out nulls by default. Therefore, it's necessary to include certain null
 checks to ensure that exclusion filters behave predictably.
 
 For instance, the below code will select only values that do not match the given value, including nulls.
 
-
 ```php
-$players = Player::get()->filter('FirstName:not', 'Sam');
 // ... WHERE "FirstName" != 'Sam' OR "FirstName" IS NULL
 // Returns rows with any value (even null) other than Sam
+$players = Player::get()->filter('FirstName:not', 'Sam');
 ```
 
 If null values should be excluded, include the null in your check.
 
-
 ```php
-$players = Player::get()->filter('FirstName:not', ['Sam', null]);
 // ... WHERE "FirstName" != 'Sam' AND "FirstName" IS NOT NULL
 // Only returns non-null values for "FirstName" that aren't Sam.
-// Strictly the IS NOT NULL isn't necessary, but is included for explicitness
+// Strictly the IS NOT NULL isn't necessary in the resulting query, but is included for explicitness
+$players = Player::get()->filter('FirstName:not', ['Sam', null]);
 ```
 
 It is also often useful to filter by all rows with either empty or null for a given field.
 
-
 ```php
-$players = Player::get()->filter('FirstName', [null, '']);
 // ... WHERE "FirstName" == '' OR "FirstName" IS NULL
 // Returns rows with FirstName which is either empty or null
+$players = Player::get()->filter('FirstName', [null, '']);
 ```
 
 ### Filtering by aggregates
@@ -449,74 +458,78 @@ $teams = Team::get()->filter('Players.Avg(PointsScored):GreaterThan', 15);
 $teams = Team::get()->filter('Players.Sum(PointsScored):LessThan', 300);
 ```
 
+[hint]
+The above examples are using "dot notation" to get the aggregations of the `Players` relation on the `Teams` model. See [Relations between Records](relations) to learn more.
+[/hint]
+
 ### filterByCallback
 
-It is also possible to filter by a PHP callback, this will force the data model to fetch all records and loop them in
-PHP, thus `filter()` or `filterAny()` are to be preferred over `filterByCallback()`.
+It is possible to filter by a PHP callback using the [`filterByCallback()`](api:SilverStripe\ORM\DataList::filterByCallback()) method. This will force the data model to fetch all records and loop them in
+PHP which will be much worse for performance, thus `filter()` or `filterAny()` are to be preferred over `filterByCallback()`.
 
 [notice]
 Because `filterByCallback()` has to run in PHP, it has a significant performance tradeoff, and should not be used on large recordsets.
 
-`filterByCallback()` will always return  an `ArrayList`.
+`filterByCallback()` will always return an `ArrayList`.
 [/notice]
 
-The first parameter to the callback is the item, the second parameter is the list itself. The callback will run once
-for each record, if the callback returns true, this record will be added to the list of returned items.
+The first parameter to the callback is the record, the second parameter is the list itself. The callback will run once
+for each record. The callback must return a boolean value. If the callback returns true, the current record will be included in the list of returned items.
 
-The below example will get all `Players` aged over 10.
+The below example will get all `Player` records aged over 10.
 
 ```php
-$players = Player::get()->filterByCallback(function($item, $list) {
-    return ($item->Age() > 10);
+$players = Player::get()->filterByCallback(function($record, $list) {
+    return ($record->Age() > 10);
 });
 ```
 
 ### Exclude
 
-The `exclude()` method is the opposite to the filter in that it removes entries from a list.
+The [`exclude()`](api:SilverStripe\ORM\DataList::exclude()) method is the opposite to `filter()` in that it determines which entries to _exclude_ from a list, where `filter()` determines which to _include_.
 
 ```php
-$players = Player::get()->exclude('FirstName', 'Sam');
-
 // SELECT * FROM Player WHERE FirstName != 'Sam'
+$players = Player::get()->exclude('FirstName', 'Sam');
 ```
 
-Remove both Sam and Sig..
+Exclude both Sam and Sig.
 
 ```php
 $players = Player::get()->exclude([
-    'FirstName' => ['Sam','Sig']
+    'FirstName' => ['Sam', 'Sig']
 ]);
 ```
 
-`Exclude` follows the same pattern as filter, so for removing only Sam Minnée from the list:
+`exclude()` follows the same pattern as filter, so for excluding anyone with both the first name "Sam" and the last name "Minnée" from the list:
 
 ```php
+// SELECT * FROM Player WHERE (FirstName != 'Sam' OR LastName != 'Minnée')
 $players = Player::get()->exclude([
     'FirstName' => 'Sam',
     'Surname' => 'Minnée',
 ]);
-
-// SELECT * FROM Player WHERE (FirstName != 'Sam' OR LastName != 'Minnée')
 ```
 
-Removing players with *either* the first name of Sam or the last name of Minnée requires multiple `->exclude` calls:
+Removing players with *either* the first name of "Sam" or the last name of "Minnée" requires multiple `exclude()` calls - or simply using the `excludeAny()` method:
 
 ```php
-$players = Player::get()->exclude('FirstName', 'Sam')->exclude('Surname', 'Minnée');
-
 // SELECT * FROM Player WHERE FirstName != 'Sam' AND LastName != 'Minnée'
+$players = Player::get()->exclude('FirstName', 'Sam')->exclude('Surname', 'Minnée');
+$players = Player::get()->excludeAny([
+    'FirstName' => 'Sam',
+    'Surname' => 'Minnée',
+]);
 ```
 
-And removing Sig and Sam with that are either age 17 or 43.
+And removing any named "Sig" or "Sam" with that are either age 17 or 43.
 
 ```php
+// SELECT * FROM Player WHERE ("FirstName" NOT IN ('Sam','Sig) OR "Age" NOT IN ('17', '43'));
 $players = Player::get()->exclude([
     'FirstName' => ['Sam', 'Sig'],
     'Age' => [17, 43]
 ]);
-
-// SELECT * FROM Player WHERE ("FirstName" NOT IN ('Sam','Sig) OR "Age" NOT IN ('17', '43'));
 ```
 
 You can use [SearchFilters](searchfilters) to add additional behavior to your `exclude` command.
@@ -534,17 +547,16 @@ You can subtract entries from a [DataList](api:SilverStripe\ORM\DataList) by pas
 
 ```php
 $sam = Player::get()->filter('FirstName', 'Sam');
-$players = Player::get();
-
-$noSams = $players->subtract($sam);
+$noSams = Player::get()->subtract($sam);
 ```
 
-Though for the above example it would probably be easier to use `filter()` and `exclude()`. A better use case could be
-when you want to find all the members that does not exist in a Group.
+Though for the above example it would probably be easier to use `filter()` and `exclude()` directly on the final list. A better use case could be
+when you want to find all the members that do not exist in a Group.
 
 ```php
-// ... Finding all members that does not belong to $group.
+// ... Finding all members that do not belong to $group.
 use SilverStripe\Security\Member;
+// Assuming we have some `Group` $group:
 $otherMembers = Member::get()->subtract($group->Members());
 ```
 
@@ -559,28 +571,24 @@ $members = Member::get()->limit(5);
 
 `limit()` accepts two arguments, the first being the amount of results you want returned, with an optional second
 parameter to specify the offset, which allows you to tell the system where to start getting the results from. The
-offset, if not provided as an argument, will default to 0.
+offset, if not provided as an argument, will default to 0 (i.e. start with the first result).
 
 ```php
 // Return 10 members with an offset of 4 (starting from the 5th result).
 $members = Member::get()->sort('Surname')->limit(10, 4);
 ```
 
-[alert]
-Note that the `limit` argument order is different from a MySQL LIMIT clause.
-[/alert]
+### Mapping classes to tables with `DataObjectSchema` {#mapping-classes-to-tables}
 
-### Mapping classes to tables with DataObjectSchema
-
-Note that in most cases, the underlying database table for any DataObject instance will be the same as the class name.
-However in cases where dealing with namespaced classes, especially when using DB schema which don't support
-slashes in table names, it is necessary to provide an alternate mapping.
+Note that by default, the underlying database table for any `DataObject` instance will be the same as the class name.
+However, relying on this default behaviour can result in table names that are too long for the database engine to support.
+We recommend explicitly declaring a table name for each `DataObject` subclass you create.
 
 For instance, the below model will be stored in the table name `BannerImage`
 
-
 ```php
 namespace SilverStripe\BannerManager;
+
 use SilverStripe\ORM\DataObject;
 
 class BannerImage extends DataObject 
@@ -591,7 +599,7 @@ class BannerImage extends DataObject
 
 Note that any model class which does not explicitly declare a `table_name` config option will have a name
 automatically generated for them. In the above case, the table name would have been
-`SilverStripe\BannerManager\BannerImage`
+`SilverStripe_BannerManager_BannerImage`
 
 When creating raw SQL queries that contain table names, it is necessary to ensure your queries have the correct
 table. This functionality can be provided by the [DataObjectSchema](api:SilverStripe\ORM\DataObjectSchema) service, which can be accessed via
@@ -600,21 +608,20 @@ equivalent version.
 
 Methods which return class names:
 
-* `tableClass($table)` Finds the class name for a given table. This also handles suffixed tables such as `Table_Live`.
-* `baseDataClass($class)` Returns the base data class for the given class.
-* `classForField($class, $field)` Finds the specific class that directly holds the given field
+* [`tableClass($table)`](api:SilverStripe\ORM\DataObjectSchema::tableClass()) - Finds the class name for a given table. This also handles suffixed tables such as `Table_Live` (see [Versioning](versioning)).
+* [`baseDataClass($class)`](api:SilverStripe\ORM\DataObjectSchema::baseDataClass()) - Returns the base data class for the given class.
+* [`classForField($class, $field)`](api:SilverStripe\ORM\DataObjectSchema::classForField()) - Finds the specific class that directly holds the given field
 
 Methods which return table names:
 
-* `tableName($class)` Returns the table name for a given class or object.
-* `baseDataTable($class)` Returns the base data class for the given class.
-* `tableForField($class, $field)` Finds the specific class that directly holds the given field and returns the table.
+* [`tableName($class)`](api:SilverStripe\ORM\DataObjectSchema::tableName()) - Returns the table name for a given class or object.
+* [`baseDataTable($class)`](api:SilverStripe\ORM\DataObjectSchema::baseDataTable()) - Returns the base data class for the given class.
+* [`tableForField($class, $field)`](api:SilverStripe\ORM\DataObjectSchema::tableForField()) - Finds the specific class that directly holds the given field and returns the table.
 
 Note that in cases where the class name is required, an instance of the object may be substituted.
 
 For example, if running a query against a particular model, you will need to ensure you use the correct
 table and column.
-
 
 ```php
 use SilverStripe\ORM\Queries\SQLSelect;
@@ -633,10 +640,10 @@ public function countDuplicates($model, $fieldToCheck)
 ### Raw SQL
 
 Occasionally, the system described above won't let you do exactly what you need to do. In these situations, we have
-methods that manipulate the SQL query at a lower level.  When using these, please ensure that all table and field names
-are escaped with double quotes, otherwise some DB backends (e.g. PostgreSQL) won't work.
+methods that manipulate the SQL query at a lower level. When using these, please ensure that all table and field names
+are escaped with double quotes, otherwise some database backends (e.g. [PostgreSQL](https://github.com/silverstripe/silverstripe-postgresql)) won't work.
 
-Under the hood, query generation is handled by the [DataQuery](api:SilverStripe\ORM\DataQuery) class. This class does provide more direct access
+Under the hood, query generation is handled by the [DataQuery](api:SilverStripe\ORM\DataQuery) class. This class provides more direct access
 to certain SQL features that `DataList` abstracts away from you.
 
 In general, we advise against using these methods unless it's absolutely necessary. If the ORM doesn't do quite what
@@ -662,57 +669,72 @@ You can specify a join with the `innerJoin` and `leftJoin` methods.  Both of the
 // Without an alias
 $members = Member::get()
     ->leftJoin("Group_Members", "\"Group_Members\".\"MemberID\" = \"Member\".\"ID\"");
+$members = Member::get()
+    ->innerJoin("Group_Members", "\"Group_Members\".\"MemberID\" = \"Member\".\"ID\"");
 
+// With an alias "Rel"
+$members = Member::get()
+    ->leftJoin("Group_Members", "\"Rel\".\"MemberID\" = \"Member\".\"ID\"", "Rel");
 $members = Member::get()
     ->innerJoin("Group_Members", "\"Rel\".\"MemberID\" = \"Member\".\"ID\"", "Rel");
 ```
 
 [alert]
-Passing a *$join* statement will filter results further by the JOINs performed against the foreign table. It will
-**not** return the additionally joined data.
+Using a join will _filter_ results further by the JOINs performed against the foreign table. It will
+**not return** the additionally joined data. For the examples above, we're still only selecting values for the fields
+on the `Member` class table.
 [/alert]
 
 ### Default Values
 
-Define the default values for all the `$db` fields. This example sets the "Status"-column on Player to "Active"
-whenever a new object is created.
+Define the default values for all the `$db` fields. This example sets the `Status` column on Player to "Active"
+whenever a new record is created.
 
 ```php
 use SilverStripe\ORM\DataObject;
 
 class Player extends DataObject 
 {
-
+    // ...
     private static $defaults = [
-        "Status" => 'Active',
+        'Status' => 'Active',
     ];
 }
 ```
 
-[notice]
-Note: Alternatively you can set defaults directly in the database-schema (rather than the object-model). See
-[Data Types and Casting](/developer_guides/model/data_types_and_casting) for details.
-[/notice]
+See [Default Values and Records](/developer_guides/model/how_tos/dynamic_default_fields/) for more about setting default values and records.
 
 ## Subclasses
 
-Inheritance is supported in the data model: separate tables will be linked together, the data spread across these
-tables. The mapping and saving logic is handled by Silverstripe CMS , you don't need to worry about writing SQL most of the
+Inheritance is supported in the data model. Separate tables will be linked together, the data spread across these
+tables depending on which class declares them. The mapping and saving logic is handled by Silverstripe CMS - you don't need to worry about writing SQL most of the
 time.
 
 For example, suppose we have the following set of classes:
 
 ```php
-use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\ORM\DataObject;
 
-class Page extends SiteTree 
+class Product extends DataObject 
 {
+    private static $table_name = 'Product';
 
-}
-class NewsPage extends Page 
-{
     private static $db = [
-        'Summary' => 'Text'
+        'SKU' => 'Text'
+    ];
+}
+
+class DigitalProduct extends Product
+{
+    private static $table_name = 'Product_Digital';
+}
+
+class Computer extends DigitalProduct
+{
+    private static $table_name = 'Product_Digital_Computer';
+
+    private static $db = [
+        'IsPreBuilt' => 'Boolean',
     ];
 }
 ```
@@ -720,43 +742,43 @@ class NewsPage extends Page
 The data for the following classes would be stored across the following tables:
 
 ```yml
-SilverStripe\CMS\Model\SiteTree:
+Product:
   ID: Int
-  ClassName: Enum('SiteTree', 'Page', 'NewsPage')
+  ClassName: Enum('Sport', 'BallSport', 'Tennis')
   Created: Datetime
   LastEdited: Datetime
-  Title: Varchar
-  Content: Text
-NewsPage:
+  SKU: Text
+Product_Digital_Computer:
   ID: Int
-  Summary: Text
+  IsPreBuilt: 'Boolean'
 ```
+
+[hint]
+Note that because `DigitalProduct` doesn't define any new fields it doesn't need its own table. We should still declare a `$table_name` though - who knows if this model might have its own table created in the future (e.g. if we add fields to it later on).
+[/hint]
 
 Accessing the data is transparent to the developer.
 
 ```php
-$news = NewsPage::get();
+$products = Computer::get();
 
-foreach($news as $article) {
-    echo $article->Title;
+foreach($products as $product) {
+    echo $product->SKU;
 }
 ```
 
 The way the ORM stores the data is this:
 
-*  "Base classes" are direct sub-classes of [DataObject](api:SilverStripe\ORM\DataObject).  They are always given a table, whether or not they have
-   special fields.  This is called the "base table". In our case, `SiteTree` is the base table.
+*  "Base classes" are direct sub-classes of [DataObject](api:SilverStripe\ORM\DataObject). They are always given a table, whether or not they declare
+   their own fields. This is called the "base table". In our case, `Product` is the base table.
+*  The base table's `ClassName` field is set to class of the given record. The column is an enumeration of all
+   subclasses of the base class (including the base class itself).
+*  Each subclass of the base object will also be given its own table *as long as it has custom fields*. In the
+   example above, `DigitalProduct` didn't define any new fields, so an extra table would be redundant.
+*  In all the tables, `ID` is the primary key. A matching `ID` number is used for all parts of a particular record:
+   record #2 in the `Product` table refers to the same object as record #2 in the `Product_Digital_Computer` table.
 
-*  The base table's ClassName field is set to class of the given record.  It's an enumeration of all possible
-   sub-classes of the base class (including the base class itself).
-
-*  Each sub-class of the base object will also be given its own table, *as long as it has custom fields*.  In the
-   example above, NewsSection didn't have its own data, so an extra table would be redundant.
-
-*  In all the tables, ID is the primary key.  A matching ID number is used for all parts of a particular record:
-   record #2 in Page refers to the same object as record #2 in [SiteTree](api:SilverStripe\CMS\Model\SiteTree).
-
-To retrieve a news article, Silverstripe CMS joins the [SiteTree](api:SilverStripe\CMS\Model\SiteTree), [Page](api:SilverStripe\CMS\Model\SiteTree\Page) and NewsPage tables by their ID fields.
+To retrieve a `Computer` record, Silverstripe CMS joins the `Product` and `Product_Digital_Computer` tables by their `ID` columns.
 
 ## Related Lessons
 * [Introduction to the ORM](https://www.silverstripe.org/learn/lessons/v4/introduction-to-the-orm-1)

--- a/en/02_Developer_Guides/00_Model/02_Relations.md
+++ b/en/02_Developer_Guides/00_Model/02_Relations.md
@@ -6,7 +6,7 @@ icon: link
 
 # Relations between Records
 
-In most situations you will likely see more than one [DataObject](api:SilverStripe\ORM\DataObject) and several classes in your data model may relate
+In most situations you will likely see more than one [`DataObject`](api:SilverStripe\ORM\DataObject) and several classes in your data model may relate
 to one another. An example of this is a `Player` object may have a relationship to one or more `Team` or `Coach` classes
 and could take part in many `Games`. Relations are a key part of designing and building a good data model.
 
@@ -15,7 +15,7 @@ Silverstripe CMS supports a number of relationship types and each relationship t
 
 ## has_one
 
-Many-to-1 and 1-to-1 relationships create a database-column called "`<relationship-name>`ID", in the example below this would be "TeamID" on the "Player"-table.
+Many-to-one and one-to-one relationships create a database-column called `<relationship-name>ID`, in the example below this would be `TeamID` on the `Player` table.
 
 ```php
 use SilverStripe\ORM\DataObject;
@@ -23,7 +23,7 @@ use SilverStripe\ORM\DataObject;
 class Player extends DataObject
 {
     private static $has_one = [
-        "Team" => Team::class,
+        'Team' => Team::class,
     ];
 }
 
@@ -39,10 +39,11 @@ class Team extends DataObject
 }
 ```
 
-This defines a relationship called `Team` which links to a `Team` class. The `ORM` handles navigating the relationship
+This defines a one-to-many relationship called `Team` which links any number of `Player` records to a single `Team` record. The ORM handles navigating the relationship
 and provides a short syntax for accessing the related object.
 
-To create a has_one/has_many relationship to core classes (File, Image, etc), reference the Classname::class, like below.
+[hint]
+Relations don't only apply to your own `DataObject` models - you can make relations to core models such as `File` and `Image` as well:
 
 ```php
 use SilverStripe\ORM\DataObject;
@@ -51,14 +52,16 @@ use SilverStripe\Assets\File;
 
 class Team extends DataObject
 {
-    private static $has_many = [
+    private static $has_one = [
         'Teamphoto' => Image::class,
         'Lineup' => File::class
     ];    
 }
 ```
 
-At the database level, the `has_one` creates a `TeamID` field on `Player`. A `has_many` field does not impose any database changes. It merely injects a new method into the class to access the related records (in this case, `Players()`)
+[/hint]
+
+At the database level, the `has_one` from our example above creates a `TeamID` field on the `Player` table. A `has_many` field does not impose any database changes. It merely injects a new method into the class to access the related records (in this case, `Players()`)
 
 ```php
 $player = Player::get()->byId(1);
@@ -70,26 +73,30 @@ echo $player->Team()->Title;
 // returns the 'Title' column on the 'Team' or `getTitle` if it exists.
 ```
 
+[info]
+Even if the `$player` record doesn't have any team record saved in its `Team` relation, `$player->Team()` will return a `Team` object. In that case, it will be an _empty_ record, with only default values applied. You can validate if that is the case by calling [`exists()`](api:SilverStripe\ORM\DataObject::exists()) on the record (e.g. `$player->Team()->exists()`).
+[/info]
+
 The relationship can also be navigated in [templates](../templates).
 
 ```ss
 <% with $Player %>
-    <% if $Team %>
+    <% if $Team.exists %>
         Plays for $Team.Title
     <% end_if %>
 <% end_with %>
 ```
 
-## Polymorphic has_one
+### Polymorphic has_one
 
-A has_one can also be polymorphic, which allows any type of object to be associated.
+A `has_one` relation can also be polymorphic, which allows any type of object to be associated.
 This is useful where there could be many use cases for a particular data structure.
 
 An additional column is created called `<relationship-name>Class`, which along
-with the ID column identifies the object.
+with the `<relationship-name>ID` column identifies the object.
 
-To specify that a has_one relation is polymorphic set the type to [api:SilverStripe\ORM\DataObject]
-Ideally, the associated has_many (or belongs_to) should be specified with dot notation.
+To specify that a `has_one` relation is polymorphic set the type to [api:SilverStripe\ORM\DataObject].
+Ideally, the associated `has_many` (or `belongs_to`) should be specified with ["dot notation"](#dot-notation).
 
 ```php
 use SilverStripe\ORM\DataObject;
@@ -97,23 +104,22 @@ use SilverStripe\ORM\DataObject;
 class Player extends DataObject
 {
     private static $has_many = [
-        "Fans" => Fan::class.".FanOf",
+        'Fans' => Fan::class.'.FanOf',
     ];
 }
 class Team extends DataObject
 {
     private static $has_many = [
-        "Fans" => Fan::class.".FanOf",
+        'Fans' => Fan::class.'.FanOf',
     ];
 }
 
-// Type of object returned by $fan->FanOf() will vary
 class Fan extends DataObject
 {
-
     // Generates columns FanOfID and FanOfClass
+    // The actual class of objects returned by $fan->FanOf() will vary
     private static $has_one = [
-        "FanOf" => DataObject::class,
+        'FanOf' => DataObject::class,
     ];
 }
 ```
@@ -126,18 +132,51 @@ be necessary. E.g. Additional parent classes for each respective relationship, o
 duplication of code.
 [/warning]
 
+### belongs_to
+
+Defines a one-to-one relationship with another object, which declares the other end of the relationship with a
+corresponding `has_one`. A single database column named `<relationship-name>ID` will be created in the object with the
+`has_one`, but the `belongs_to` by itself will not create a database field.
+
+Similarly with `has_many` below, [dot notation](#dot-notation) can (and for best practice _should_) be used to explicitly specify the `has_one` which refers to this relation.
+This is not mandatory unless the relationship would be otherwise ambiguous.
+
+[hint]
+You can use `RelationValidationService` for validation of relationships. This tool will point out the relationships which may need a review. See [Validating relations](#validating-relations) for more information.
+[/hint]
+
+```php
+use SilverStripe\ORM\DataObject;
+
+class Team extends DataObject
+{
+    private static $has_one = [
+        'Coach' => Coach::class
+    ];
+}
+
+class Coach extends DataObject
+{
+    private static $belongs_to = [
+        'Team' => Team::class.'.Coach'
+    ];
+}
+```
+
 ## has_many
 
-Defines 1-to-many joins. As you can see from the previous example, `$has_many` goes hand in hand with `$has_one`.
+Defines one-to-many joins. As you can see from the previous example, `$has_many` goes hand in hand with `$has_one`.
 
 [alert]
-Please specify a $has_one-relationship on the related child-class as well, in order to have the necessary accessors
-available on both ends. To add a $has_one-relationship on core classes, yml config settings can be used:
+When defining a `has_many` relation, you _must_ specify a `has_one` relationship on the related class as well. To add a `has_one` relation on core classes, yml config settings can be used:
+
 ```yml
 SilverStripe\Assets\Image:
   has_one:
-    MyDataObject: MyDataObject
+    Team: App\Model\Team
 ```
+
+Note that in some cases you may be better off using a `many_many` relation instead. Carefully consider whether you are defining a "one-to-many" or a "many-to-many" relationship.
 [/alert]
 
 ```php
@@ -153,33 +192,53 @@ class Team extends DataObject
         'Players' => Player::class,
     ];
 }
+
 class Player extends DataObject
 {
-
     private static $has_one = [
-        "Team" => Team::class,
+        'Team' => Team::class,
     ];
 }
 ```
 
-Much like the `has_one` relationship, `has_many` can be navigated through the `ORM` as well. The only difference being
-you will get an instance of [HasManyList](api:SilverStripe\ORM\HasManyList) rather than the object.
+Much like the `has_one` relationship, `has_many` can be navigated through the ORM as well. The only difference being
+you will get an instance of [`HasManyList`](api:SilverStripe\ORM\HasManyList) rather than the object.
 
 ```php
+use SilverStripe\ORM\HasManyList;
+
 $team = Team::get()->first();
 
-echo $team->Players();
-// [HasManyList]
+/** @var HasManyList $players */
+$players = $team->Players();
 
-echo $team->Players()->Count();
-// returns '14';
+/** @var int $numPlayers */
+$numPlayers = $players->Count();
 
-foreach($team->Players() as $player) {
+foreach($players as $player) {
     echo $player->FirstName;
 }
 ```
 
-To specify multiple `$has_many` to the same object you can use dot notation to distinguish them like below:
+If you're using the default scaffolded form fields with multiple `has_one` relationships, you will end up with a CMS field for each relation. If you don't want these you can remove them, referring to them with as `<relation-name>ID`:
+
+```php
+class Company extends DataObject
+{
+    // ...
+
+    public function getCMSFields()
+    {
+        $fields = parent::getCMSFields();
+        $fields->removeByName(['ManagerID', 'CleanerID']);
+        return $fields;
+    }
+}
+```
+
+## Dot notation {#dot-notation}
+
+To specify multiple `has_many`, `many_many`, `belongs_to`, or `belongs_many_many` relationships to the same model class (and as a general best practice) you can use dot notation to distinguish them like below:
 
 ```php
 use SilverStripe\ORM\DataObject;
@@ -187,123 +246,45 @@ use SilverStripe\ORM\DataObject;
 class Person extends DataObject
 {
     private static $has_many = [
-        "Managing" => Company::class.".Manager",
-        "Cleaning" => Company::class.".Cleaner",
+        'Managing' => Company::class.'.Manager',
+        'Cleaning' => Company::class.'.Cleaner',
     ];
 }
+
 class Company extends DataObject
 {
     private static $has_one = [
-        "Manager" => Person::class,
-        "Cleaner" => Person::class,
+        'Manager' => Person::class,
+        'Cleaner' => Person::class,
     ];
 }
 ```
 
-Multiple `$has_one` relationships are okay if they aren't linking to the same object type. Otherwise, they have to be
-named. With that said, naming is recommended in all cases as it makes your code more resilient to change. Adding new relationships is easier when you don't need to review and update existing ones.
+Multiple `has_many` or `belongs_to` relationships are okay _without_ dot notation if they aren't linking to the same model class. Otherwise, using dot notation is required. With that said, dot notation is recommended in all cases as it makes your code more resilient to change. Adding new relationships is easier when you don't need to review and update existing ones.
 
-You can use `RelationValidationService` for validation of relationships. This tool will point out the relationships which may need a review.
+[hint]
+You can use `RelationValidationService` for validation of relationships. This tool will point out the relationships which may need a review. See [Validating relations](#validating-relations) for more information.
+[/hint]
 
-If you're using the default scaffolded form fields with multiple `has_one` relationships, you will end up with a CMS field for each relation. If you don't want these you can remove them by their IDs:
-
-```php
-public function getCMSFields()
-{
-    $fields = parent::getCMSFields();
-    $fields->removeByName(['ManagerID', 'CleanerID']);
-    return $fields;
-}
-```
-
-## belongs_to
-
-Defines a 1-to-1 relationship with another object, which declares the other end of the relationship with a
-corresponding `$has_one`. A single database column named `<relationship-name>ID` will be created in the object with the
-`$has_one`, but the $belongs_to by itself will not create a database field. This field will hold the ID of the object
-declaring the `$belongs_to`.
-
-Similarly with `$has_many`, dot notation can be used to explicitly specify the `$has_one` which refers to this relation.
-This is not mandatory unless the relationship would be otherwise ambiguous.
-
-You can use `RelationValidationService` for validation of relationships. This tool will point out the relationships which may need a review.
-
-```php
-use SilverStripe\ORM\DataObject;
-
-class Team extends DataObject
-{
-
-    private static $has_one = [
-        'Coach' => Coach::class
-    ];
-}
-class Coach extends DataObject
-{
-
-    private static $belongs_to = [
-        'Team' => Team::class.'.Coach'
-    ];
-}
-```
-
-## many_many
-
-Defines many-to-many joins, which uses a third table created between the two to join pairs.
-There are two ways in which this can be declared, which are described below, depending on
-how the developer wishes to manage this join table.
+## many_many relationships {#many-many}
 
 [warning]
-Please specify a $belongs_many_many-relationship on the related class as well, in order
-to have the necessary accessors available on both ends. You can use `RelationValidationService` for validation of relationships. This tool will point out the relationships which may need a review.
-
-Example configuration:
-
-```yaml
-SilverStripe\Dev\Validation\RelationValidationService:
-  output_enabled: true
-```
-
+Please specify a `belongs_many_many` relationship on the related class as well in order to have the necessary accessors available on both ends. See [`belongs_many_many`](#belongs-many-many) for more information.
 [/warning]
 
-Much like the `has_one` relationship, `many_many` can be navigated through the `ORM` as well.
-The only difference being you will get an instance of [ManyManyList](api:SilverStripe\ORM\ManyManyList) or
-[ManyManyThroughList](api:SilverStripe\ORM\ManyManyThroughList) rather than the object.
+Defines many-to-many relationships. This type of relationship requires a new table which has an `ID` column to represent the relationship itself and a column for each of the IDs of the related records.
 
-```php
-$team = Team::get()->byId(1);
+There are two ways this relationship can be declared which are (described below) depending on how the developer wishes to manage this join table.
 
-$supporters = $team->Supporters();
-// returns a 'ManyManyList' instance.
-```
-
-You can add objects to the relation simply by calling `add()` on the list:
-
-```php
-$team = Team::get()->byId(1);
-$supporter = Supporter::get()->first();
-$team->Supporters()->add($supporter);
-```
-
-You can also set the extra fields data either while adding the item, or after the fact:
-
-```php
-$team = Team::get()->byId(1);
-// Add extra fields data while adding the item to the list
-$supporter = Supporter::get()->first();
-$team->Supporters()->add($supporter, ['Ranking' => 1]);
-
-// Add extra fields data after the item is already in the list
-$supporter2 = Supporter::get()->find('ID:not', $supporter->ID);
-$team->Supporters()->add($supporter2);
-$team->Supporters()->setExtraData($supporter2->ID, ['Ranking' => 2]);
-```
+[hint]
+You can use `RelationValidationService` for validation of relationships. This tool will point out the relationships which may need a review. See [Validating relations](#validating-relations) for more information.
+[/hint]
 
 ### Automatic many_many table
 
 If you specify only a single class as the other side of the many-many relationship, then a
-table will be automatically created between the two (this-class)_(relationship-name), will
-be created with a pair of ID fields.
+table will be automatically created between the two. It will be the table name of the class which declares the `many_many` relationship, suffixed with the relationship name (e.g. `Team_Supporters`).
+The table will be created with an `ID` column to represent the relationship itself and a column for each of the IDs of the related records
 
 Extra fields on the mapping table can be created by declaring a `many_many_extraFields`
 config to add extra columns.
@@ -314,7 +295,7 @@ use SilverStripe\ORM\DataObject;
 class Team extends DataObject
 {
     private static $many_many = [
-        "Supporters" => Supporter::class,
+        'Supporters' => Supporter::class,
     ];
 
     private static $many_many_extraFields = [
@@ -327,7 +308,7 @@ class Team extends DataObject
 class Supporter extends DataObject
 {
     private static $belongs_many_many = [
-        "Supports" => Team::class,
+        'Supports' => Team::class,
     ];
 }
 ```
@@ -336,35 +317,34 @@ To ensure this `many_many` is sorted by "Ranking" by default you can add this to
 
 ```yaml
 Team_Supporters:
-  default_sort: '"Team_Supporter"."Ranking" ASC'
+  default_sort: 'Ranking ASC'
 ```
 
-`Team_Supporters` is the table name automatically generated for the many_many relation in this case.
+`Team_Supporters` is the table name automatically generated for the `many_many` relation in this case.
 
-### many_many through relationship joined on a separate DataObject
+### many_many through relationship joined on a separate DataObject {#many-many-through}
 
-If necessary, a third DataObject class can instead be specified as the joining table,
+If necessary, a third `DataObject` class can instead be specified as the joining table,
 rather than having the ORM generate an automatically scaffolded table. This has the following
 advantages:
 
- - Allows versioning of the mapping table, including support for the
-   [ownership api](/developer_guides/model/versioning).
- - Allows support of other extensions on the mapping table (e.g. subsites).
- - Extra fields can be managed separately to the joined dataobject, even via a separate
-   GridField or form.
+- Allows versioning of the mapping table, including support for the
+ownership api (see [Versioning](/developer_guides/model/versioning) for more information).
+- Allows support of other extensions on the mapping table (e.g. for [subsites](https://github.com/silverstripe/silverstripe-subsites) or localisation via [fluent](https://github.com/tractorcow-farm/silverstripe-fluent)).
+- Extra fields can easily be managed separately via the joined dataobject, even via a separate `GridField` or form.
 
-This is declared via array syntax, with the following keys on the many_many:
- - `through` Class name of the mapping table
- - `from` Name of the has_one relationship pointing back at the object declaring many_many
- - `to` Name of the has_one relationship pointing to the object declaring belongs_many_many.
+This is declared via array syntax, with the following keys on the `many_many` relation:
+- `through`: Class name of the mapping table
+- `from`: Name of the `has_one` relationship pointing back at the object declaring `many_many`
+- `to`: Name of the `has_one` relationship pointing to the object declaring `belongs_many_many`.
 
-Just like any normal DataObject, you can apply a default sort which will be applied when
+Just like any normal `DataObject`, you can apply a default sort which will be applied when
 accessing many many through relations.
 
 Note: The `through` class must not also be the name of any field or relation on the parent
 or child record.
 
-The syntax for `belongs_many_many` is unchanged.
+The [syntax for `belongs_many_many`](#belongs-many-many) is unchanged.
 
 ```php
 use SilverStripe\ORM\DataObject;
@@ -379,6 +359,7 @@ class Team extends DataObject
         ]
     ];
 }
+
 class Supporter extends DataObject
 {
     // It can be useful, but not necessary, to include the reverse relation name via dot-notation
@@ -387,6 +368,7 @@ class Supporter extends DataObject
         'Supports' => Team::class,
     ];
 }
+
 class TeamSupporter extends DataObject
 {
     private static $db = [
@@ -398,31 +380,33 @@ class TeamSupporter extends DataObject
         'Supporter' => Supporter::class,
     ];
 
-    private static $default_sort = '"TeamSupporter"."Ranking" ASC';
+    private static $default_sort = 'Ranking ASC';
 }
 ```
 
-In order to filter on the join table during queries, you can use the class name of the joining table
-for any sql conditions.
+You can filter on the relation by the extra fields automatically, assuming they don't conflict with names of fields on other tables in the query.
 
 ```php
 $team = Team::get()->byId(1);
-$supporters = $team->Supporters()->where(['"TeamSupporter"."Ranking"' => 1]);
+$supporters = $team->Supporters()->filter(['Ranking' => 1]);
 ```
 
-Note: ->filter() currently does not support joined fields natively due to the fact that the
-query for the join table is isolated from the outer query controlled by DataList.
+[hint]
+For records accessed in a [`ManyManyThroughList`](api:SilverStripe\ORM\ManyManyThroughList), you can access the join record (e.g. for our example above a `TeamSupporter` instance) by calling [`getJoin()`](api:SilverStripe\ORM\DataObject::getJoin()) or as the `$Join` property in templates.
+[/hint]
 
-### Polymorphic many_many (Experimental)
+#### Polymorphic many_many
 
-Using many_many through, it is possible to support polymorphic relations on the mapping table.
-Note, that this feature is currently experimental, and has certain limitations:
- - This feature only works with many_many through
- - This feature will only allow polymorphic many_many, but not belongs_many_many. However,
-   you can have a has_many relation to the mapping table on this side, and iterate through this
-   to collate parent records.
+Using many_many through it is possible to support polymorphic relations on the mapping table.
+Note, that this feature has certain limitations:
+- This feature only works with many_many through
+- This feature will only allow polymorphic `many_many`, but not `belongs_many_many`.
+  - You can have a `has_many` relation to the join table where you would normally use `belongs_many_many`, and iterate through it
+to collate parent records - but note that this will trigger a database query for every single record in the relation (because relations are not eager loaded), and filtering/etc would require additional complexity.
 
-For instance, this is how you would link an arbitrary object to many_many tags.
+Note that this works by leveraging a polymorphic `has_one` relation on the join class. See [Polymorphic has_one](#polymorphic-has-one) for more information about that relation type.
+
+For instance, this is how you would link an arbitrary object to `many_many` tags.
 
 ```php
 use SilverStripe\ORM\DataObject;
@@ -431,16 +415,18 @@ class SomeObject extends DataObject
 {
     // This same many_many may also exist on other classes
     private static $many_many = [
-        "Tags" => [
+        'Tags' => [
             'through' => TagMapping::class,
             'from' => 'Parent',
             'to' => 'Tag',
         ]
     ];
 }
+
 class Tag extends DataObject
 {
     // has_many works, but belongs_many_many will not
+    // note that we are explicitly declaring the join class "TagMapping" here instead of the "SomeObject" class.
     private static $has_many = [
         'TagMappings' => TagMapping::class,
     ];
@@ -448,7 +434,7 @@ class Tag extends DataObject
     /**
      * Example iterator placeholder for belongs_many_many.
      * This is a list of arbitrary types of objects
-     * @return Generator|DataObject[]
+     * @return Generator
      */
     public function TaggedObjects()
     {
@@ -456,8 +442,8 @@ class Tag extends DataObject
             yield $mapping->Parent();
         }
     }
-
 }
+
 class TagMapping extends DataObject
 {   
     private static $has_one = [
@@ -467,37 +453,102 @@ class TagMapping extends DataObject
 }
 ```
 
-### Using many_many in templates
+### Using many_many relationships
+
+Much like `has_one` and `has_many` relationships, `many_many` can be navigated through the ORM as well.
+The only difference being you will get an instance of [ManyManyList](api:SilverStripe\ORM\ManyManyList) or
+[ManyManyThroughList](api:SilverStripe\ORM\ManyManyThroughList) returned.
+
+```php
+use SilverStripe\ORM\ManyManyList;
+use SilverStripe\ORM\ManyManyThroughList;
+
+$team = Team::get()->byId(1);
+
+/** @var MayManyList|ManyManyThroughList $supporters */
+$supporters = $team->Supporters();
+```
+
+You can add objects to the relation simply by calling `add()` on the relation list:
+
+```php
+$team = Team::get()->byId(1);
+$supporter = Supporter::get()->first();
+$team->Supporters()->add($supporter);
+```
+
+#### Setting many_many extra fields data
+
+You can set the extra fields data at the same time as adding the record to the relationship list:
+
+```php
+$team = Team::get()->byId(1);
+$supporter = Supporter::get()->first();
+$team->Supporters()->add($supporter, ['Ranking' => 1]);
+```
+
+You can also declare extra fields data later on. For regular `many_many` relationships [using an automatic `many_many` table](#automatic-many-many-table) you can use the `setExtraData()` method on the list:
+
+```php
+$team = Team::get()->byId(1);
+$supporter = Supporter::get()->first();
+$team->Supporters()->add($supporter);
+$team->Supporters()->setExtraData($supporter->ID, ['Ranking' => 2]);
+```
+
+For [`many_many` through relationships](#many-many-through), just treat the join record the same as you would any other `DataObject` record.
+
+```php
+$team = Team::get()->byId(1);
+$supporter = Supporter::get()->first();
+$team->Supporters()->add($supporter);
+
+$joinRecord = TeamSupporter::get()->filter(['TeamID' => $team->Id, 'SupporterID' => $supporter->ID])->first();
+$joinRecord->Ranking = 2;
+$joinRecord->write();
+```
+
+#### Using many_many in templates
 
 The relationship can also be navigated in [templates](../templates).
-The joined record can be accessed via `Join` or `TeamSupporter` property (many_many through only)
 
 ```ss
 <% with $Supporter %>
     <% loop $Supports %>
-        Supports $Title <% if $TeamSupporter %>(rank $TeamSupporter.Ranking)<% end_if %>
+        Supports $Title (rank $Ranking)
     <% end_loop %>
 <% end_with %>
 ```
 
-You can also use `$Join` in place of the join class alias (`$TeamSupporter`), if your template
-is class-agnostic and doesn't know the type of the join table.
+[hint]
+For many_many through relations, the join record can be accessed via [`$Join`](api:SilverStripe\ORM\DataObject::getJoin()) or the actual relation name (e.g. `$TeamSupporter`). This is useful if your template is class-agnostic and doesn't know specifically what relation names are used.
+
+This also provides three ways to access the extra fields on a many_many through relation:
+
+```ss
+<% with $Supporter %>
+    <% loop $Supports %>
+        Access extrafields directly: $Ranking
+        Access extrafields using getJoin: $Join.Ranking
+        Access extrafields using the somewhat-magic join-class selector: $TeamSupporter.Ranking
+    <% end_loop %>
+<% end_with %>
+```
+[/hint]
 
 ## belongs_many_many
 
-The belongs_many_many represents the other side of the relationship on the target data class.
-When using either a basic many_many or a many_many through, the syntax for belongs_many_many is the same.
+The `belongs_many_many` relation represents the other side of the `many_many` relationship.
+When using either a basic `many_many` or a `many_many` through, the syntax for `belongs_many_many` is the same.
 
-To specify multiple $many_manys between the same classes, specify use the dot notation to
+To specify multiple `many_many` relationships between the same classes, specify use [dot notation](#dot-notation) to
 distinguish them like below:
-
 
 ```php
 use SilverStripe\ORM\DataObject;
 
 class Category extends DataObject
 {
-
     private static $many_many = [
         'Products' => Product::class,
         'FeaturedProducts' => Product::class,
@@ -516,87 +567,115 @@ class Product extends DataObject
 If you're unsure about whether an object should take on `many_many` or `belongs_many_many`,
 the best way to think about it is that the object where the relationship will be edited
 (i.e. via checkboxes) should contain the `many_many`. For instance, in a `many_many` of
-Product => Categories, the `Product` should contain the `many_many`, because it is much
-more likely that the user will select Categories for a Product than vice-versa.
-
+`Product` => `Category`, the `Product` model should contain the `many_many` side of the relationship, because it is much
+more likely that the user will select categories for a product than vice-versa.
 
 ## Cascading deletions
 
 Relationships between objects can cause cascading deletions, if necessary, through configuration of the
-`cascade_deletes` config on the parent class.
+`cascade_deletes` config on the class that declares the relationship.
+
+[alert]
+Declaring `cascade_deletes` implies delete permissions on the listed objects.
+Built-in controllers using delete operations check `canDelete()` on the owner, but not on the owned object.
+[/alert]
 
 ```php
 use SilverStripe\ORM\DataObject;
 
-class ParentObject extends DataObject {
+class ParentObject extends DataObject
+{
     private static $has_one = [
         'Child' => ChildObject::class,
     ];
+
     private static $cascade_deletes = [
         'Child',
     ];
 }
-class ChildObject extends DataObject {
-}
 ```
 
-In this example, when the Parent object is deleted, the Child specified by the has_one relation will also
-be deleted. Note that all relation types (has_many, many_many, belongs_many_many, belongs_to, and has_one)
+In this example, when the parent object is deleted, the child specified by the `has_one` relation will also
+be deleted. Note that all relation types (`has_many`, `many_many`, `belongs_many_many`, `belongs_to`, and `has_one`)
 are supported, as are methods that return lists of objects but do not correspond to a physical database relation.
 
-If your object is versioned, cascade_deletes will also act as "cascade unpublish", such that any unpublish
+If your object is versioned, `cascade_deletes` will also act as "cascade unpublish", such that any unpublish
 on a parent object will trigger unpublish on the child, similarly to how `owns` causes triggered publishing.
 See the [versioning docs](/developer_guides/model/versioning) for more information on ownership.
 
 [alert]
-Declaring cascade_deletes implies delete permissions on the listed objects.
-Built-in controllers using delete operations check canDelete() on the owner, but not on the owned object.   
+If the child model is not versioned, `cascade_deletes` will result in the child record being _deleted_ if the parent is unpublished! Be sure to check whether both sides of the relationship are versioned before declaring `cascade_deletes`.
 [/alert]
 
 ## Cascading duplications
 
 Similar to `cascade_deletes` there is also a `cascade_duplicates` config which works in much the same way.
-When you invoke `$dataObject->duplicate()`, relation names specified by this config will be duplicated
+When you invoke [`duplicate()`](api:SilverStripe\ORM\DataObject::duplicate()) on a `DataObject` record,
+relation names specified by this config will be duplicated
 and saved against the new clone object.
 
 Note that duplications will act differently depending on the kind of relation:
- - Exclusive relationships (e.g. has_many, belongs_to) will be explicitly duplicated.
- - Non-exclusive many_many will not be duplicated, but the mapping table values will instead
-   be copied for this record.
- - Non-exclusive has_one relationships are not normally necessary to duplicate, since both parent and clone
-   can normally share the same relation ID. However, if this is declared in `cascade_duplicates` any
-   has one will be similarly duplicated as though it were an exclusive relationship.
+
+- Records in one-to-many or many-to-many relationships (e.g. `has_many`, `has_one`, and `belongs_to`) will be explicitly duplicated.
+- Records in many-to-many (i.e. `many_many` and `belongs_many_many`) relationships will _not_ be duplicated, but the mapping table values will instead
+be copied so that the original records are related to the new duplicate record.
 
 For example:
 
 ```php
 use SilverStripe\ORM\DataObject;
 
-class ParentObject extends DataObject {
+class ParentObject extends DataObject
+{
     private static $many_many = [
-        'RelatedChildren' => ChildObject::class,
+        // None of the ManyManyExample records in this relationship will be duplicated.
+        // Instead each row in the join table will be copied, connecting the new duplicated ParentObject
+        // record with each of the original ManyManyExample records in the original relationship.
+        'ManyManyExamples' => ManyManyExample::class,
     ];
-    private static $cascade_duplicates = [ 'RelatedChildren' ];
-}
-class ChildObject extends DataObject {
+
+    private static $has_many = [
+        // Each HasManyExample record in this relationship will be duplicated, and the new records will all have the
+        // duplicated ParentObject record's ID in their has_one relation ID column.
+        'HasManyExamples' => HasManyExample::class,
+    ];
+
+    private static $has_one = [
+        // The HasOneExample record will be duplicated, and the new duplicated records will be related to one another.
+        'HasOneExample' => HasOneExample::class,
+    ];
+
+    private static $cascade_duplicates = [
+        'ManyManyExamples',
+        'HasManyExamples',
+        'HasOneExample',
+    ];
 }
 ```
 
-When duplicating objects you can disable recursive duplication by passing in `false` to the second
-argument of duplicate().
+When duplicating objects you can determine which relationships (if any) should be cascade-duplicated by passing specific values to the second argument of `duplicate()`.
 
-E.g.
+By default (or by explicitly passing `null`) this will respect the `cascade_duplicates` configuration. Passing `false` results in only duplicating the record for which the method is being invoked. Passing an array of relation names will act as though the passed in relation names were in the `cascade_duplicates` configuration.
 
 ```php
 $parent = ParentObject::get()->first();
-$dupe = $parent->duplicate(true, false);
+
+// Only duplicate the `$parent` record
+$dupe = $parent->duplicate(relations: false);
+
+// Duplicate the `$parent` record, and cascade duplicate the "Children" relation (ignoring any cascade_duplicates configuration)
+$dupe = $parent->duplicate(relations: ['Children']);
 ```
+
+[info]
+The first parameter in `duplicate()` is `$doWrite` and determines whether the new duplicate record(s) will be written to the database. The second parameter is `$relations`, and it works as described above.
+[/info]
 
 ## Adding relations
 
-Adding new items to a relations works the same, regardless if you're editing a **has_many** or a **many_many**. They are
-encapsulated by [HasManyList](api:SilverStripe\ORM\HasManyList) and [ManyManyList](api:SilverStripe\ORM\ManyManyList), both of which provide very similar APIs, e.g. an `add()`
-and `remove()` method.
+Adding new items to a relation works the same regardless if you're editing a `has_many` or a `many_many` relationship. They are
+encapsulated by [`HasManyList`](api:SilverStripe\ORM\HasManyList) and [`ManyManyList`](api:SilverStripe\ORM\ManyManyList), both of which provide very similar APIs (e.g. an `add()`
+and `remove()` method).
 
 ```php
 $team = Team::get()->byId(1);
@@ -610,12 +689,20 @@ $supporter->write();
 $team->Supporters()->add($supporter);
 ```
 
+Note that `add()` and `remove()` happen instantaneously. You don't have to call `write()` on anything after using those methods.
+
+[hint]
+To set what record is in a `has_one` relation, just set the `<relation-name>ID` field - e.g: `$player->TeamID = $team->ID;`
+
+Don't forget to write the record (`$player->write();`)!
+[/hint]
+
 ## Custom Relations
 
 You can use the ORM to get a filtered result list without writing any SQL. For example, this snippet gets you the
-"Players"-relation on a team, but only containing active players.
+`Players` relation on a team, but only containing active players.
 
-See [DataObject::$has_many](api:SilverStripe\ORM\DataObject::$has_many) for more info on the described relations.
+See [Filtering Results](/developer_guides/model/data_model_and_orm/#filtering-results) for more information.
 
 ```php
 use SilverStripe\ORM\DataObject;
@@ -623,7 +710,7 @@ use SilverStripe\ORM\DataObject;
 class Team extends DataObject
 {
     private static $has_many = [
-        "Players" => Player::class
+        'Players' => Player::class
     ];
 
     public function ActivePlayers()
@@ -636,13 +723,23 @@ class Team extends DataObject
 
 [notice]
 Adding new records to a filtered `RelationList` like in the example above doesn't automatically set the filtered
-criteria on the added record.
+criteria on the added record - the record is added to the relation but is otherwise unaltered.
+
+```php
+$newPlayer = Player::create(['Status' => 'Inactive']);
+$newPlayer->write();
+
+$playersList = Team()->get_one()->Players()->filter('Status', 'Active');
+$playersList->add($newPlayer);
+// Still returns 'Inactive'
+$status = $newPlayer->Status;
+```
 [/notice]
 
 ## Relations on Unsaved Objects
 
-You can also set *has_many* and *many_many* relations before the `DataObject` is saved. This behavior uses the
-[UnsavedRelationList](api:SilverStripe\ORM\UnsavedRelationList) and converts it into the correct `RelationList` when saving the `DataObject` for the first
+You can also set `has_many` and `many_many` relations before the `DataObject` is saved. This behavior uses the
+[UnsavedRelationList](api:SilverStripe\ORM\UnsavedRelationList) and converts it into the correct [`RelationList`](api:SilverStripe\ORM\RelationList) subclass when saving the `DataObject` for the first
 time.
 
 This unsaved lists will also recursively save any unsaved objects that they contain.
@@ -650,6 +747,65 @@ This unsaved lists will also recursively save any unsaved objects that they cont
 As these lists are not backed by the database, most of the filtering methods on `DataList` cannot be used on a list of
 this type. As such, an `UnsavedRelationList` should only be used for setting a relation before saving an object, not
 for displaying the objects contained in the relation.
+
+## Validating relations
+
+The [`RelationValidationService`](api:SilverStripe\Dev\Validation\RelationValidationService) can be used to check if your relations are set up according to best practices, and is very useful for debugging unexpected behaviour with relations. It is disabled by default.
+
+To enable this service, set the following yaml configuration, which will give you validation output every time you run `dev/build`.
+
+```yaml
+SilverStripe\Dev\Validation\RelationValidationService:
+  output_enabled: true
+```
+
+By default, this service only inspects relations for classes which have either no namespace or a namespace beginning with `App\`. You can declare your own namespace prefixes by setting the `allow_rules` configuration:
+
+```yaml
+SilverStripe\Dev\Validation\RelationValidationService:
+  allow_rules:
+    # using the "app" key you can override the default "App" namespace
+    app: 'MyApp'
+    # you can add any namespace declarations with-or-without keys
+    - 'MyOrg'
+    # you can declare as much of of a namespace as you want - only classes which begin with
+    # any one of the mentioned namespace prefixes will be allowed.
+    - 'AnotherOrg\MyModule'
+```
+
+You can also tell the service to ignore classes whose namespace starts a certain way:
+
+```yaml
+SilverStripe\Dev\Validation\RelationValidationService:
+  deny_rules:
+    - 'MyApp\SpecialCases'
+```
+
+If you have relations that you've intentionally set up in a way that the validation service warns against, you can tell it to ignore those specific relations by setting `deny_relations` config. Syntax for this is `<class>.<relation>`.
+
+```yaml
+SilverStripe\Dev\Validation\RelationValidationService:
+  deny_relations:
+    - 'App\Model\Player.Teams'
+```
+
+### Validating relations outside dev/build
+
+If you want to, you can invoke the `RelationValidationService` at any time in PHP code.
+
+```php
+use SilverStripe\Dev\Validation\RelationValidationService;
+
+$messages = RelationValidationService::singleton()->validateRelations();
+```
+
+If you are doing this to debug some specific class(es), you might want to use the `inspectClasses()` method, which disregards the `allow_rules`, `deny_rules`, and `deny_relations` configuration specified above.
+
+```php
+use SilverStripe\Dev\Validation\RelationValidationService;
+
+$messages = RelationValidationService::singleton()->inspectClasses([Team::class, Player::class]);
+```
 
 ## Link Tracking
 
@@ -671,5 +827,6 @@ It is also possible to control the visibility of the `File Tracking` tab by sett
 
 * [HasManyList](api:SilverStripe\ORM\HasManyList)
 * [ManyManyList](api:SilverStripe\ORM\ManyManyList)
+* [ManyManyThroughList](api:SilverStripe\ORM\ManyManyThroughList)
 * [DataObject](api:SilverStripe\ORM\DataObject)
 * [LinkTracking](api:SilverStripe\CMS\Model\SiteTreeLinkTracking)

--- a/en/02_Developer_Guides/00_Model/03_Lists.md
+++ b/en/02_Developer_Guides/00_Model/03_Lists.md
@@ -10,9 +10,11 @@ Whenever using the ORM to fetch records or navigate relationships you will recei
 either [DataList](api:SilverStripe\ORM\DataList) or [RelationList](api:SilverStripe\ORM\RelationList). This object gives you the ability to iterate over each of the results or
 modify.
 
+There's a lot more information about filtering and sorting lists in the [Introduction to the Data Model and ORM](/developer_guides/model/data_model_and_orm/) section.
+
 ## Iterating over the list
 
-[SS_List](api:SilverStripe\ORM\SS_List) implements `IteratorAggregate`, allowing you to loop over the instance.
+[`SS_List`](api:SilverStripe\ORM\SS_List) extends the [`IteratorAggregate`](https://www.php.net/manual/en/class.iteratoraggregate.php) interface, allowing you to loop over the instance.
 
 ```php
 use SilverStripe\Security\Member;
@@ -27,65 +29,62 @@ foreach($members as $member) {
 Or in the template engine:
 
 ```ss
+<%-- Assuming there is a "getMembers()" method or a "Members" relation --%>
 <% loop $Members %>
-    <!-- -->
+    $Name
 <% end_loop %>
 ```
 
 ## Finding an item by value
 
-```php
-// $list->find($key, $value);
+You can use the [`find()`](api:SilverStripe\ORM\SS_List::find()) method to get a single item based on the value of one of its properties.
 
-//
+```php
 $members = Member::get();
 
+// returns a string e.g. 'Sam'
 echo $members->find('ID', 4)->FirstName;
-// returns 'Sam'
 ```
 
 ## Maps
 
-A map is an array where the array indexes contain data as well as the values. You can build a map from any list
+A map is like an array, where the indexes contain data as well as the values. You can build a map from any list by calling the [`map()](api:SilverStripe\ORM\SS_List::map()) method.
 
 ```php
 $members = Member::get()->map('ID', 'FirstName');
 
-// $members = [
-//    1 => 'Sam'
-//    2 => 'Sig'
-//    3 => 'Will'
-// ];
+foreach ($members as $id => $firstName) {
+    // Do something here with that data
+}
 ```
 
-This functionality is provided by the [Map](api:SilverStripe\ORM\Map) class, which can be used to build a map around any `SS_List`.
+This functionality is provided by the [`Map`](api:SilverStripe\ORM\Map) class, which can be used to build a map from any `SS_List`. You can instantiate a new `Map` object using the `new` keyword as well.
 
 ```php
-$members = Member::get();
-$map = new Map($members, 'ID', 'FirstName');
+$membersMap = new Map(Member::get(), 'ID', 'FirstName');
 ```
 
 ## Column
 
+You can get all of the values for a single property by calling the [`column()`](api:SilverStripe\ORM\SS_List::column()) method.
+
 ```php
-$members = Member::get();
-
-echo $members->column('Email');
-
 // returns [
-//    'sam@silverstripe.com',
-//    'sig@silverstripe.com',
-//    'will@silverstripe.com'
+//    'sam@example.com',
+//    'sig@example.com',
+//    'will@example.com'
 // ];
+$emailAddresses = Member::get()->column('Email');
 ```
 
 ## Iterating over a large list {#chunkedFetch}
 
-When iterating over a DataList, all DataObjects in the list will be loaded in memory. This can consume a lot of memory when working with a large data set.
+When iterating over a `DataList`, the ORM will create a [`Generator`](https://www.php.net/manual/en/language.generators.overview.php). This means we don't have all of the `DataObject` records in the list instantiated in memory, but the ORM _does_ fetch all of the data about those records and loads that data in memory. This can consume a lot of memory when working with a large data set.
 
-To limit the number of DataObjects loaded in memory, you can use the `chunkedFetch()` method on your DataList. In most cases, you can iterate over the results of `chunkedFetch()` the same way you would iterate over your DataList. Internally, `chunkedFetch()` will split your DataList query into smaller queries and keep running through them until it runs out of results.
+To limit the amount of data loaded in memory, you can use the [`chunkedFetch()`](api:SilverStripe\ORM\DataList::chunkedFetch()) method on your `DataList`. In most cases, you can iterate over the results of `chunkedFetch()` the same way you would iterate over your `DataList`. Internally, `chunkedFetch()` will split the database query into smaller queries and keep running through them until it runs out of results.
 
 ```php
+// Without using chunked fetch, all of the data for all of the Member records will be fetched from the database in a single query
 $members = Member::get();
 foreach ($members as $member) {
     echo $member->Email;
@@ -98,9 +97,12 @@ foreach ($members as $member) {
 }
 ```
 
-`chunkedFetch()` will respect any filter or sort condition applied to the DataList. By default, chunk will limit each query to 1000 results. You can explicitly set this limit by passing an integer to `chunkedFetch()`.
+`chunkedFetch()` will respect any filter or sort condition applied to the `DataList`.
+
+By default, chunk will limit each query to 1000 results. You can explicitly set this limit by passing an integer to `chunkedFetch()`.
 
 ```php
+// Each query will only return 10 results at a time
 $members = Member::get()
     ->filter('Email:PartialMatch', 'silverstripe.com')
     ->sort('Email')
@@ -111,13 +113,13 @@ foreach ($members as $member) {
 ```
 
 There are some limitations:
-* `chunkedFetch()` will ignore any limit or offset you have applied to your DataList
+* `chunkedFetch()` will ignore any limit or offset you have applied to your `DataList`
 * you cannot "count" a chunked list or do any other call against it aside from iterating it
 * while iterating over a chunked list, you cannot perform any operation that would alter the order of the items.
 
 ## ArrayList
 
-[ArrayList](api:SilverStripe\ORM\ArrayList) exists to wrap a standard PHP array in the same API as a database backed list.
+[`ArrayList`](api:SilverStripe\ORM\ArrayList) exists to wrap a standard PHP array in the same API as a database backed list.
 
 ```php
 $sam = Member::get()->byId(5);
@@ -127,8 +129,8 @@ $list = new ArrayList();
 $list->push($sam);
 $list->push($sig);
 
-echo $list->Count();
 // returns '2'
+$numItems = $list->Count();
 ```
 
 ## Related Lessons

--- a/en/02_Developer_Guides/00_Model/04_Data_Types_and_Casting.md
+++ b/en/02_Developer_Guides/00_Model/04_Data_Types_and_Casting.md
@@ -1,18 +1,18 @@
 ---
-title: Data Types, Overloading and Casting
+title: Data types, Overriding and Casting
 summary: Learn how data is stored going in and coming out of the ORM and how to modify it.
 icon: code
 ---
 
-# Data Types and Casting
+# Data types and Casting
 
-Each model in a Silverstripe CMS [DataObject](api:SilverStripe\ORM\DataObject) will handle data at some point. This includes database columns such as 
-the ones defined in a `$db` array or simply a method that returns data for the template. 
+Each model in a Silverstripe CMS [`DataObject`](api:SilverStripe\ORM\DataObject) will handle data at some point. This includes database columns such as
+the ones defined in a `$db` array and methods that return data for for use in templates.
 
-A Data Type is represented in Silverstripe CMS by a [DBField](api:SilverStripe\ORM\FieldType\DBField) subclass. The class is responsible for telling the ORM 
-about how to store its data in the database and how to format the information coming out of the database, i.e. on a template.
+A data type is represented in Silverstripe CMS by a [`DBField`](api:SilverStripe\ORM\FieldType\DBField) subclass. The class is responsible for telling the ORM
+how to store its data in the database and how to format the information coming out of the database, i.e. on a template.
 
-In the `Player` example, we have four database columns each with a different data type (Int, Varchar).
+In the `Player` example, we have four database columns each with a different data type (`Int`, `Varchar`, etc).
 
 **app/src/Player.php**
 
@@ -32,53 +32,43 @@ class Player extends DataObject
 
 ## Available Types
 
+*  `'BigInt'`: An 8-byte signed integer field (see: [DBBigInt](api:SilverStripe\ORM\FieldType\DBBigInt)).
 *  `'Boolean'`: A boolean field (see: [DBBoolean](api:SilverStripe\ORM\FieldType\DBBoolean)).
-*  `'Currency'`: A number with 2 decimal points of precision, designed to store currency values (see: [DBCurrency](api:SilverStripe\ORM\FieldType\DBCurrency)).
+*  `'Currency'`: A number with 2 decimal points of precision, designed to store currency values. Only supports single currencies (see: [DBCurrency](api:SilverStripe\ORM\FieldType\DBCurrency)).
 *  `'Date'`: A date field (see: [DBDate](api:SilverStripe\ORM\FieldType\DBDate)).
+*  `'Datetime'`: A date/time field (see: [DBDatetime](api:SilverStripe\ORM\FieldType\DBDatetime)).
+*  `'DBClassName'`: A special enumeration for storing class names (see: [DBClassName](api:SilverStripe\ORM\FieldType\DBClassName)).
 *  `'Decimal'`: A decimal number (see: [DBDecimal](api:SilverStripe\ORM\FieldType\DBDecimal)).
-*  `'Enum'`: An enumeration of a set of strings (see: [DBEnum](api:SilverStripe\ORM\FieldType\DBEnum)).
-*  `'HTMLText'`: A variable-length string of up to 2MB, designed to store HTML (see: [DBHTMLText](api:SilverStripe\ORM\FieldType\DBHTMLText)).
+*  `'Double'`: A floating point number with double precision (see: [DBDouble](api:SilverStripe\ORM\FieldType\DBDouble)).
+*  `'Enum'`: An enumeration of a set of strings that can store a single value (see: [DBEnum](api:SilverStripe\ORM\FieldType\DBEnum)).
+*  `'Float'`: A floating point number (see: [DBFloat](api:SilverStripe\ORM\FieldType\DBFloat)).
+*  `'Foreignkey'`: A special `Int` field used for foreign keys in `has_one` relationships (see: [DBForeignKey](api:SilverStripe\ORM\FieldType\DBForeignKey)).
+*  `'HTMLFragment'`: A variable-length string of up to 2MB, designed to store HTML. Doesn't process [shortcodes](/developer_guides/extending/shortcodes/). (see: [DBHTMLText](api:SilverStripe\ORM\FieldType\DBHTMLText)).
+*  `'HTMLText'`: A variable-length string of up to 2MB, designed to store HTML. Processes [shortcodes](/developer_guides/extending/shortcodes/). (see: [DBHTMLText](api:SilverStripe\ORM\FieldType\DBHTMLText)).
 *  `'HTMLVarchar'`: A variable-length string of up to 255 characters, designed to store HTML (see: [DBHTMLVarchar](api:SilverStripe\ORM\FieldType\DBHTMLVarchar)).
-*  `'Int'`: An integer field (see: [DBInt](api:SilverStripe\ORM\FieldType\DBInt)).
+*  `'Int'`: A 32-bit signed integer field (see: [DBInt](api:SilverStripe\ORM\FieldType\DBInt)).
+*  `'Locale'`: A field for storing locales (see: [DBLocale](api:SilverStripe\ORM\FieldType\DBLocale)).
+*  `'Money'`: Similar to Currency, but with localisation support (see: [DBMoney](api:SilverStripe\ORM\FieldType\DBMoney)).
+*  `'MultiEnum'`: An enumeration set of strings that can store multiple values (see: [DBMultiEnum](api:SilverStripe\ORM\FieldType\DBMultiEnum)).
 *  `'Percentage'`: A decimal number between 0 and 1 that represents a percentage (see: [DBPercentage](api:SilverStripe\ORM\FieldType\DBPercentage)).
-*  `'Datetime'`: A date / time field (see: [DBDatetime](api:SilverStripe\ORM\FieldType\DBDatetime)).
+*  `'PolymorphicForeignKey'`: A special ForeignKey class that handles relations with arbitrary class types (see: [DBPolymorphicForeignKey](api:SilverStripe\ORM\FieldType\DBPolymorphicForeignKey)).
+*  `'PrimaryKey'`: A special type Int field used for primary keys. (see: [DBPrimaryKey](api:SilverStripe\ORM\FieldType\DBPrimaryKey)).
 *  `'Text'`: A variable-length string of up to 2MB, designed to store raw text (see: [DBText](api:SilverStripe\ORM\FieldType\DBText)).
 *  `'Time'`: A time field (see: [DBTime](api:SilverStripe\ORM\FieldType\DBTime)).
 *  `'Varchar'`: A variable-length string of up to 255 characters, designed to store raw text (see: [DBVarchar](api:SilverStripe\ORM\FieldType\DBVarchar)).
+*  `'Year'`: Represents a single year field (see: [DBYear](api:SilverStripe\ORM\FieldType\DBYear)).
 
-See the [API documentation](api:SilverStripe\ORM\FieldType\DBField) for a full list of available Data Types. You can define your own [DBField](api:SilverStripe\ORM\FieldType\DBField) instances if required as well. 
+See the [API documentation](api:SilverStripe\ORM\FieldType) for a full list of available data types. You can define your own [`DBField`](api:SilverStripe\ORM\FieldType\DBField) instances if required as well.
 
-## Default Values
+## Default Values for new database columns {#default-values}
 
-### Default values for new objects
+One way to define default values for new records is to use the `$defaults` configuration property, which is described in default in [Dynamic Default Values](how_tos/dynamic_default_fields).
+That will only affect _new_ records, however. If you are adding a new field to an existing `DataObject` model, you may want to apply a default value for that field to _existing_ records as well.
 
-For complex default values for newly instantiated objects see [Dynamic Default Values](how_tos/dynamic_default_fields). 
-For simple values you can make use of the `$defaults` array. For example:
-
-```php
-use SilverStripe\ORM\DataObject;
-
-class Car extends DataObject 
-{   
-    private static $db = [
-        'Wheels' => 'Int',
-        'Condition' => 'Enum(["New","Fair","Junk"])'
-    ];
-    
-    private static $defaults = [
-        'Wheels' => 4,
-        'Condition' => 'New'
-    ];
-}
-```
-
-### Default values for new database columns
-
-When adding a new `$db` field to a DataObject you can specify a default value
-to be applied to all existing records when the column is added in the database
-for the first time. This will also be applied to any newly created objects
-going forward. You do this by passing an argument for the default value in your 
-`$db` items. 
+When adding a new `$db` field to a `DataObject`, you can specify a default value
+to be applied to all existing and new records when the column is added in the database
+for the first time. You do this by passing an argument for the default value in your 
+`$db` items.
 
 For integer values, the default is the first parameter in the field specification.
 For string values, you will need to declare this default using the options array.
@@ -93,18 +83,22 @@ class Car extends DataObject
 {   
     private static $db = [
         'Wheels' => 'Int(4)',
-        'Condition' => 'Enum(["New","Fair","Junk"], "New")',
+        'Condition' => 'Enum(["New","Fair","Junk"], "Fair")',
         'Make' => 'Varchar(["default" => "Honda"])',
-    );
+    ];
 }
 ```
 
+[info]
+`Enum` fields will use the first defined value as the default if you don't explicitly declare one. In the example above, the default value would be "New" if it hadn't been declared.
+[/info]
+
 ## Formatting Output
 
-The Data Type does more than setup the correct database schema. They can also define methods and formatting helpers for
-output. You can manually create instances of a Data Type and pass it through to the template. 
+The data type does more than set up the correct database schema. They can also define methods and formatting helpers for
+output. You can manually create instances of a data type and pass it through to the template.
 
-In this case, we'll create a new method for our `Player` that returns the full name. By wrapping this in a [DBVarchar](api:SilverStripe\ORM\FieldType\DBVarchar)
+In this case, we'll create a new method for our `Player` that returns the full name. By wrapping this in a [`DBVarchar`](api:SilverStripe\ORM\FieldType\DBVarchar)
 object we can control the formatting and it allows us to call methods defined from `Varchar` as `LimitCharacters`.
 
 **app/src/Player.php**
@@ -127,19 +121,72 @@ Then we can refer to a new `Name` column on our `Player` instances. In templates
 ```php
 $player = Player::get()->byId(1);
 
-echo $player->Name;
-// returns "Sam Minnée"
+// returns the `DBVarChar` instance, which has the value "Sam Minnée"
+$name = $player->Name;
 
-echo $player->getName();
-// returns "Sam Minnée";
+// returns the `DBVarChar` instance, which has the value "Sam Minnée"
+$name = $player->getName();
 
-echo $player->getName()->LimitCharacters(2);
 // returns "Sa…"
+$name = $player->getName()->LimitCharacters(2);
+```
+
+[hint]
+For `DBField` types that represent strings, you can just treat the instance like a string.
+
+```php
+$player = Player::get()->byId(1);
+// returns the string "Name: Sam Minnée"
+$string = 'Name: ' . $player->Name;
+```
+
+For other types, we need to make sure we get the value from the `DBField` instance first:
+
+```php
+$player = Player::get()->byId(1);
+// where `getAge()` returns a `DBInt` field:
+// this will throw a "TypeError: Unsupported operand types: SilverStripe\ORM\FieldType\DBInt + int"
+$player->Age + 5;
+// returns the correct int value as a result
+$player->Age->value + 5;
+```
+
+That doesn't apply to templates, where we can just treat all `DBField` instances as though they are primitives _or_ call methods on them:
+
+```ss
+<% with $player %>
+    <%-- prints out the name, e.g. Sam Minnée --%>
+    $Name
+    <%-- prints out the name in all caps, e.g. SAM MINNÉE --%>
+    $Name.UpperCase
+<% end_with %>
+```
+[/hint]
+
+On the most basic level, the `DBField` classes can be used for simple conversions from one value to another, e.g. to round a number.
+
+```php
+use SilverStripe\ORM\FieldType\DBField;
+// returns 1.23
+DBField::create_field('Double', 1.23456)->Round(2);
+```
+
+Of course that's much more verbose than using the equivalent built-in PHP [`round()`](https://www.php.net/manual/en/function.round.php) function. The power of [DBField](api:SilverStripe\ORM\FieldType\DBField) comes with its more sophisticated helpers, like showing the time difference to the current date:
+
+```php
+use SilverStripe\ORM\FieldType\DBField;\
+// returns "30 years ago"
+DBField::create_field('Date', '1982-01-01')->TimeDiff();
 ```
 
 ## Casting
 
-Rather than manually returning objects from your custom functions. You can use the `$casting` property.
+Most objects in Silverstripe CMS extend from [ViewableData](api:SilverStripe\View\ViewableData), which means they know how to present themselves in a view
+context. Rather than manually returning objects from your custom functions. You can use the `$casting` configuration property. This casting only happens when you get the values in a template, so calling the method in your PHP code will always return the raw value.
+
+[hint]
+While these examples are using `DataObject` subclasses, you can use the `$casting` configuration property on _any_ `ViewableData` subclass.
+[/hint]
 
 ```php
 use SilverStripe\ORM\DataObject;
@@ -147,7 +194,7 @@ use SilverStripe\ORM\DataObject;
 class Player extends DataObject 
 {
     private static $casting = [
-        "Name" => 'Varchar',
+        'Name' => 'Varchar',
     ];
     
     public function getName() 
@@ -157,81 +204,70 @@ class Player extends DataObject
 }
 ```
 
-The properties on any Silverstripe CMS object can be type casted automatically, by transforming its scalar value into an 
+Using this configuration, properties, fields, and methods on any Silverstripe CMS model can be type casted automatically in templates, by transforming its scalar value into an 
 instance of the [DBField](api:SilverStripe\ORM\FieldType\DBField) class, providing additional helpers. For example, a string can be cast as a [DBText](api:SilverStripe\ORM\FieldType\DBText) 
 type, which has a `FirstSentence()` method to retrieve the first sentence in a longer piece of text.
 
-On the most basic level, the class can be used as simple conversion class from one value to another, e.g. to round a 
-number.
+As mentioned above, this leaves you free to use the raw values in your PHP code while giving you all of the helper methods of the `DBField` instances in your templates.
 
 ```php
-use SilverStripe\ORM\FieldType\DBField;
-DBField::create_field('Double', 1.23456)->Round(2); // results in 1.23
+$player = Player::get()->byId(1);
+
+// returns the string "Sam Minnée"
+$name = $player->Name;
+
+// returns the string "Sam Minnée"
+$name = $player->getName();
+
+// throws an exception, since `getName()` returns a string, not a `DBVarchar` instance
+$name = $player->getName()->LimitCharacters(2);
 ```
 
-Of course that's much more verbose than the equivalent PHP call. The power of [DBField](api:SilverStripe\ORM\FieldType\DBField) comes with its more 
-sophisticated helpers, like showing the time difference to the current date:
-
-```php
-use SilverStripe\ORM\FieldType\DBField;
-DBField::create_field('Date', '1982-01-01')->TimeDiff(); // shows "30 years ago"
+```ss
+<% with $player %>
+    <%-- prints out the name, e.g. Sam Minnée --%>
+    $Name
+    <%-- prints out the name in all caps, e.g. SAM MINNÉE --%>
+    $Name.UpperCase
+<% end_with %>
 ```
 
-## Casting ViewableData
-
-Most objects in Silverstripe CMS extend from [ViewableData](api:SilverStripe\View\ViewableData), which means they know how to present themselves in a view 
-context. Through a `$casting` array, arbitrary properties and getters can be casted:
+You can get the casted `DBField` instance of these properties by calling the [`obj()`](api:SilverStripe\View\ViewableData::obj()) method:
 
 ```php
-use SilverStripe\View\ViewableData;
-
-class MyObject extends ViewableData 
-{
-    
-    private static $casting = [
-        'MyDate' => 'Date'
-    ];
-
-    public function getMyDate() 
-    {
-        return '1982-01-01';
-    }
-}
-
-$obj = new MyObject;
-$obj->getMyDate(); // returns string
-$obj->MyDate; // returns string
-$obj->obj('MyDate'); // returns object
-$obj->obj('MyDate')->InPast(); // returns boolean
+$player = Player::get()->byId(1);
+$player->getName(); // returns string
+$player->Name; // returns string
+$player->obj('Name'); // returns DBVarchar instance
+$player->obj('Name')->LimitCharacters(2); // returns string
 ```
 
 ## Casting HTML Text
 
-The database field types [DBHTMLVarchar](api:SilverStripe\ORM\FieldType\DBHTMLVarchar)/[DBHTMLText](api:SilverStripe\ORM\FieldType\DBHTMLText) and [DBVarchar](api:SilverStripe\ORM\FieldType\DBVarchar)/[DBText](api:SilverStripe\ORM\FieldType\DBText) are exactly the same in 
-the database.  However, the template engine knows to escape fields without the `HTML` prefix automatically in templates,
-to prevent them from rendering HTML interpreted by browsers. This escaping prevents attacks like CSRF or XSS (see 
-"[security](../security)"), which is important if these fields store user-provided data.
+The database field types [`DBHTMLVarchar`](api:SilverStripe\ORM\FieldType\DBHTMLVarchar)/[`DBHTMLText`](api:SilverStripe\ORM\FieldType\DBHTMLText) and [`DBVarchar`](api:SilverStripe\ORM\FieldType\DBVarchar)/[`DBText`](api:SilverStripe\ORM\FieldType\DBText) are exactly the same in 
+the database. However, the template engine knows to escape the non-HTML variants automatically in templates,
+to prevent them from rendering HTML interpreted by browsers. This escaping prevents attacks like CSRF or XSS (see
+[security](../security)), which is important if these fields store user-provided data.
 
 See the [Template casting](/developer_guides/templates/casting) section for controlling casting in your templates.
 
-## Overloading
+## Overriding
 
-"Getters" and "Setters" are functions that help save fields to our [DataObject](api:SilverStripe\ORM\DataObject) instances. By default, the 
-methods `getField()` and `setField()` are used to set column data.  They save to the protected array, `$obj->record`. 
-We can overload the default behavior by making a function called "get`<fieldname>`" or "set`<fieldname>`".
+"Getters" and "Setters" are functions that help save fields to our [DataObject](api:SilverStripe\ORM\DataObject) instances. By default, the
+methods `getField()` and `setField()` are used to set column data.  They save to the protected array, `$obj->record`.
+We can override the default behavior by making a method called "`get<fieldname>()`" or "`set<fieldname>()`".
 
-The following example will use the result of `getStatus` instead of the 'Status' database column. We can refer to the
+The following example will use the result of `getCost()` instead of the `Cost` database column. We can refer to the
 database column using `getField()`.
 
 ```php
 use SilverStripe\ORM\DataObject;
 
 /**
- * @property Float $Cost
+ * @property float $Cost
  */
 class Product extends DataObject
 {
-
     private static $db = [
         'Title' => 'Varchar(255)',
         'Cost' => 'Int', //cost in pennies/cents
@@ -246,9 +282,12 @@ class Product extends DataObject
     {
         return $this->setField('Cost', $value * 100);
     }
-
 }
 ```
+
+[hint]
+Note that in the example above we've used a PHPDoc comment to indicate that the `$Cost` property is a `float`, even though the database field type is `Int`. This is because the `getCost()` getter method will automatically be used when trying to access `Cost` as a property (i.e. `$product->Cost` will return the result of `$product->getCost()`).
+[/hint]
 
 ## API Documentation
 

--- a/en/02_Developer_Guides/00_Model/07_Permissions.md
+++ b/en/02_Developer_Guides/00_Model/07_Permissions.md
@@ -11,13 +11,19 @@ checks. Often it makes sense to centralize those checks on the model, regardless
 
 The API provides four methods for this purpose: `canEdit()`, `canCreate()`, `canView()` and `canDelete()`.
 
+[hint]
+Versioned models have additional permission methods - see [Version specific `can` methods](versioning#permission-methods).
+[/hint]
+
 Since they're PHP methods, they can contain arbitrary logic matching your own requirements. They can optionally receive 
 a `$member` argument, and default to the currently logged in member (through `Security::getCurrentUser()`).
 
 [notice]
-By default, all `DataObject` subclasses can only be edited, created and viewed by users with the 'ADMIN' permission 
-code.
+By default, all `DataObject` subclasses can only be edited, created and viewed by users with the 'ADMIN' permission code.
+Make sure you implement these methods for models which should be editable by members with more restrictive permission models.
 [/notice]
+
+In this example, the `MyDataObject` model can be viewed, edited, deleted, and created by any user with the `CMS_ACCESS_CMSMain` permission code, aka "Access to 'Pages' section".
 
 ```php
 use SilverStripe\Security\Permission;
@@ -47,11 +53,80 @@ class MyDataObject extends DataObject
 }
 ```
 
+It is good practice to let extensions extend permissions unless you _explicitly_ want a very restrictive permissions model. This is already done by default in the implementations of these methods in `DataObject`.
+
+You might also want to validate that the parent class doesn't deny access for a given action.
+
+```php
+use SilverStripe\Security\Permission;
+
+class MyDataObject extends SomeParentObject 
+{
+    public function canView($member = null) 
+    {
+        // If any extension returns false, the result will be false
+        // otherwise if any extension returns true, the result will be true
+        $extended = $this->extendedCan(__FUNCTION__, $member);
+        // The line below is checking that there is any value other than null, but depending on your
+        // use case you may want to explicitly check for a `false` value instead, and ignore any true values,
+        // e.g. if you don't want extensions saying members CAN perform this action before you've done your own checks.
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        // If no extensions return true or false, check for a specific permission here.
+        return Permission::check('CMS_ACCESS_CMSMain', 'any', $member);
+    }
+
+    public function canEdit($member = null) 
+    {
+        // If the parent class says the member can't perform this action, don't let them do it.
+        // Be careful though - if the parent class doesn't explicitly implement canEdit(), you will end up
+        // only allowing ADMIN's access by calling the implementation in the DataObject class.
+        if (!parent::canEdit($member)) {
+            return false;
+        }
+
+        // If the parent object doesn't say the member can't perform the action, do our own checks.
+        return Permission::check('CMS_ACCESS_CMSMain', 'any', $member);
+    }
+}
+
+```
+
+See the [User Permissions](/developer_guides/security/permissions/) section for more information about defining permissions.
+
 [alert]
-These checks are not enforced on low-level ORM operations such as `write()` or `delete()`, but rather rely on being 
-checked in the invoking code. The CMS default sections as well as custom interfaces like [ModelAdmin](api:SilverStripe\Admin\ModelAdmin) or 
-[GridField](api:SilverStripe\Forms\GridField\GridField) already enforce these permissions.
+These checks are not enforced on low-level ORM operations such as `write()` or `delete()`, but rather rely on being
+checked in the invoking code. The CMS default sections as well as custom interfaces like [`ModelAdmin`](api:SilverStripe\Admin\ModelAdmin) or
+[`GridField`](api:SilverStripe\Forms\GridField\GridField) already enforce these permissions.
 [/alert]
+
+## Defining permissions in extensions
+
+You can extend the permissions checks for and `DataObject` by implementing an [`Extension`](api:SilverStripe\Core\Extension).
+
+It is good practice to only return `null` or `false` from these methods. Returning `false` means the user is _not_ allowed to perform the action, and `null` means the record should perform the rest of its own permission checks to validate if the user can perform the action.
+
+If you return `true` from these methods, you're saying the user _is_ allowed to perform the action, and that the model shouldn't perform any more permissions checks.
+
+```php
+use SilverStripe\Core\Extension;
+use SilverStripe\Security\Permission;
+
+class PermissionsExtension extends Extension
+{
+    public function canView()
+    {
+        if (!Permission::check('CMS_ACCESS_CMSMain', 'any', $member)) {
+            return false;
+        }
+        return null;
+    }
+}
+```
+
+See [Extensions and DataExtensions](/developer_guides/extending/extensions/) for more information about extensions.
 
 ## API Documentation
 

--- a/en/02_Developer_Guides/00_Model/08_SQL_Select.md
+++ b/en/02_Developer_Guides/00_Model/08_SQL_Select.md
@@ -4,16 +4,17 @@ summary: Write and modify direct database queries through SQLExpression subclass
 iconBrand: searchengin
 ---
 
-# SQLSelect
+# SQL Queries
 
-## Introduction
+Most of the time you will be using the ORM abstraction layer to interact with the database
+(see [Introduction to the Data Model and ORM](/developer_guides/model/data_model_and_orm)),
+but sometimes you may need to do something very complex or specific which is hard to do with
+that abstraction.
 
-An object representing a SQL select query, which can be serialized into a SQL statement. 
-It is easier to deal with object-wrappers than string-parsing a raw SQL-query. 
-This object is used by the Silverstripe CMS ORM internally.
+Silverstripe CMS provides a lower level abstraction layer, which is used by the Silverstripe CMS ORM internally.
 
 Dealing with low-level SQL is not encouraged, since the ORM provides
-powerful abstraction APIs (see [datamodel](/developer_guides/model/data_model_and_orm)). 
+powerful abstraction APIs.
 Records in collections are lazy loaded,
 and these collections have the ability to run efficient SQL
 such as counts or returning a single column.
@@ -26,12 +27,16 @@ use SilverStripe\ORM\DB;
 use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\Security\Member;
 
+// Get the table for the "Member" class with ANSI quotes
+$memberTable = DB::get_conn()->escapeIdentifier(
+    DataObject::getSchema()->tableName(Member::class)
+);
+
 // Through raw SQL.
-$count = DB::query('SELECT COUNT(*) FROM "Member"')->value();
+$count = DB::query('SELECT COUNT(*) FROM ' . $memberTable)->value();
 
 // Through SQLSelect abstraction layer.
-$query = new SQLSelect();
-$count = $query->setFrom('Member')->setSelect('COUNT(*)')->value();
+$count = SQLSelect::create('COUNT(*)', $memberTable)->execute()->value();
 
 // Through the ORM.
 $count = Member::get()->count();
@@ -40,13 +45,13 @@ $count = Member::get()->count();
 If you do use raw SQL, you'll run the risk of breaking 
 various assumptions the ORM and code based on it have:
 
-*  Custom getters/setters (object property can differ from database column)
-*  DataObject hooks like `onBeforeWrite()` and `onBeforeDelete()`
+*  Custom getters/setters (object property values can differ from database column values)
+*  DataObject hooks like `onBeforeWrite()` and `onBeforeDelete()` if running low-level `INSERT` or `UPDATE` queries
 *  Automatic casting
 *  Default values set through objects
-*  Database abstraction
+*  Database abstraction (some `DataObject` classes may not have their own tables, or may need a `JOIN` with other tables to get all of their field values)
 
-We'll explain some ways to use *SELECT* with the full power of SQL, 
+We'll explain some ways to use the low-level APIs with the full power of SQL,
 but still maintain a connection to the ORM where possible.
 
 [warning]
@@ -56,20 +61,51 @@ how to properly prepare user input and variables for use in queries
 
 ## Usage
 
+### Getting table names
+
+While you could hardcode table names into your SQL queries, that invites human error and means you have to make sure you know exactly what table stores which data for every class in the class hierarchy of the model you're interested in. Luckily, the [`DataObjectSchema`](api:SilverStripe\ORM\DataObjectSchema) class knows all about the database schema for your `DataObject` models. The following methods in particular may be useful to you:
+
+* [`baseDataTable()`](api:SilverStripe\ORM\DataObjectSchema::baseDataTable()): Get the name of the database table which holds the base data (i.e. `ID`, `ClassName`, `Created`, etc) for a given `DataObject` class
+* [`classHasTable()`](api:SilverStripe\ORM\DataObjectSchema::classHasTable()): Check if there is a table in the database for a given `DataObject` class (i.e. whether that class defines columns not already present in another class further up the class hierarchy)
+* [`sqlColumnForField()`](api:SilverStripe\ORM\DataObjectSchema::sqlColumnForField()): Get the ANSI-quoted table and column name for a given `DataObject` field (in `"Table"."Field"` format)
+* [`tableForField()`](api:SilverStripe\ORM\DataObjectSchema::tableForField()): Get the table name in the class hierarchy which contains a given field column.
+* [`tableName()`](api:SilverStripe\ORM\DataObjectSchema::tableName()): Get table name for the given class. Note that this does not confirm a table actually exists (or should exist), but returns the name that would be used if this table did exist. Male sure to call `classHasTable()` before using this table name in a query.
+
+[hint]
+While the default database connector will work fine without explicitly ANSI-quoting table names in queries, it is good practice to make sure they are quoted (especially if you're writing these queries in a module that will be publicly shared) to ensure your queries will work on other database connectors such as [`PostgreSQLDatabase`](https://github.com/silverstripe/silverstripe-postgresql) which explicitly require ANSI quoted table names.
+
+You can do that by passing the raw table name into [`DB::get_conn()->escapeIdentifier()`](api:SilverStripe\ORM\Connect\Database::escapeIdentifier()), which will ensure it is correctly escaped according to the rules of the currently active database connector.
+[/hint]
+
+[notice]
+Because of the way the ORM interacts with class inheritance, some models will spread their data across multiple tables. See [Joining tables for a DataObject inheritance chain](#joins-for-inheritance) below for information about how to handle that scenario.
+[/notice]
+
 ### SELECT
 
-Selection can be done by creating an instance of `SQLSelect`, which allows
-management of all elements of a SQL SELECT query, including columns, joined tables,
+Selection can be done by creating an instance of [`SQLSelect`](api:SilverStripe\ORM\Queries\SQLSelect), which allows
+management of all elements of a SQL `SELECT` query, including columns, joined tables,
 conditional filters, grouping, limiting, and sorting.
 
-E.g.:
+E.g:
 
 ```php
+$schema = DataObject::getSchema();
+$playerTableName = DB::get_conn()->escapeIdentifier($schema->baseDataTable(Player::class));
+
 $sqlQuery = new SQLSelect();
-$sqlQuery->setFrom('Player');
-$sqlQuery->selectField('FieldName', 'Name');
+$sqlQuery->setFrom($playerTableName);
+
+// Add a column to the `SELECT ()` clause
+$sqlQuery->selectField('FieldName');
+// You can pass an alias for the field in as the second argument
 $sqlQuery->selectField('YEAR("Birthday")', 'Birthyear');
-$sqlQuery->addLeftJoin('Team','"Player"."TeamID" = "Team"."ID"');
+
+// Join another table onto the query
+$joinOnClause = $schema->sqlColumnForField(Player::class, 'TeamID') . ' = ' . $schema->sqlColumnForField(Team::class, 'ID');
+$sqlQuery->addLeftJoin($teamTableName, $joinOnClause);
+
+// There are methods for most SQL clauses, such as WHERE, ORDER BY, GROUP BY, etc
 $sqlQuery->addWhere(['YEAR("Birthday") = ?' => 1982]);
 // $sqlQuery->setOrderBy(...);
 // $sqlQuery->setGroupBy(...);
@@ -89,93 +125,105 @@ foreach($result as $row) {
 }
 ```
 
-The result of `SQLSelect::execute()` is an array lightly wrapped in a database-specific subclass of [Query](api:SilverStripe\ORM\Connect\Query). 
-This class implements the *Iterator*-interface, and provides convenience-methods for accessing the data.
+[info]
+There's a lot to this API - we highly recommend that you check out the PHPDoc comments on the methods in this class to learn more about the specific usages of each - for example, the [`addWhere()`](api:SilverStripe\ORM\Queries\SQLSelect::addWhere()) method's PHPDoc includes multiple examples of different syntaxes that can be passed into it.
+[/info]
+
+The result of [`SQLSelect::execute()`](api:SilverStripe\ORM\Queries\SQLSelect::execute()) is an array lightly wrapped in a database-specific subclass of [`Query`](api:SilverStripe\ORM\Connect\Query).
+This class implements the [`IteratorAggregate`](https://www.php.net/manual/en/class.iteratoraggregate.php) interface, and provides convenience methods for accessing the data.
 
 ### DELETE
 
-Deletion can be done either by calling `DB::query`/`DB::prepared_query` directly,
-by creating a `SQLDelete` object, or by transforming a `SQLSelect` into a `SQLDelete`
+Deletion can be done either by creating a [`SQLDelete`](api:SilverStripe\ORM\Queries\SQLDelete) object, or by transforming a `SQLSelect` into a `SQLDelete`
 object instead.
 
 For example, creating a `SQLDelete` object:
 
 ```php
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
 use SilverStripe\ORM\Queries\SQLDelete;
 
+$schema = DataObject::getSchema();
+$siteTreeTable = DB::get_conn()->escapeIdentifier($schema->baseDataTable(SiteTree::class));
+
 $query = SQLDelete::create()
-    ->setFrom('"SiteTree"')
-    ->setWhere(['"SiteTree"."ShowInMenus"' => 0]);
+    ->setFrom($siteTreeTable)
+    ->setWhere([$schema->sqlColumnForField(SiteTree::class, 'ShowInMenus') => 0]);
 $query->execute();
 ```
 
 Alternatively, turning an existing `SQLSelect` into a delete:
 
 ```php
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Queries\SQLSelect;
 
+$schema = DataObject::getSchema();
+$siteTreeTable = DB::get_conn()->escapeIdentifier($schema->baseDataTable(SiteTree::class));
+
 $query = SQLSelect::create()
-    ->setFrom('"SiteTree"')
-    ->setWhere(['"SiteTree"."ShowInMenus"' => 0])
+    ->setFrom($siteTreeTable)
+    ->setWhere([$schema->sqlColumnForField(SiteTree::class, 'ShowInMenus') => 0])
     ->toDelete();
 $query->execute();
 ```
 
-Directly querying the database:
-
-```php
-use SilverStripe\ORM\DB;
-DB::prepared_query('DELETE FROM "SiteTree" WHERE "SiteTree"."ShowInMenus" = ?', [0]);
-```
-
 ### INSERT/UPDATE
 
-INSERT and UPDATE can be performed using the `SQLInsert` and `SQLUpdate` classes.
+`INSERT` and `UPDATE` can be performed using the [`SQLInsert`](api:SilverStripe\ORM\Queries\SQLInsert) and [`SQLUpdate`](api:SilverStripe\ORM\Queries\SQLUpdate) classes.
 These both have similar aspects in that they can modify content in
 the database, but each are different in the way in which they behave.
 
-Previously, similar operations could be performed by using the `DB::manipulate`
-function which would build the INSERT and UPDATE queries on the fly. This method
-still exists, but internally uses `SQLUpdate` / `SQLInsert`, although the actual
-query construction is now done by the `DBQueryBuilder` object.
+These operations can be performed in batches by using the [`DB::manipulate`](api:SilverStripe\ORM\DB::manipulate())
+method, which internally uses `SQLUpdate` / `SQLInsert`.
 
-Each of these classes implement the interface `SQLWriteExpression`, noting that each
-accepts write key/value pairs in a number of similar ways. These include the following
+Each of these classes implement the [`SQLWriteExpression`](api:SilverStripe\ORM\Queries\SQLWriteExpression) interface, noting that each
+accepts key/value pairs in a number of similar ways. These include the following
 API methods:
 
- * `addAssignments` - Takes a list of assignments as an associative array of key -> value pairs,
-   but also supports SQL expressions as values if necessary
- * `setAssignments` - Replaces all existing assignments with the specified list
- * `getAssignments` - Returns all currently given assignments, as an associative array
+ * [`addAssignments()`](api:SilverStripe\ORM\Queries\SQLWriteExpression::addAssignments()) - Takes a list of assignments as an associative array of key => value pairs,
+   where the value can also be an SQL expression.
+ * [`setAssignments()`](api:SilverStripe\ORM\Queries\SQLWriteExpression::setAssignments()) - Replaces all existing assignments with the specified list
+ * [`getAssignments()`](api:SilverStripe\ORM\Queries\SQLWriteExpression::getAssignments()) - Returns all currently given assignments, as an associative array
    in the format `['Column' => ['SQL' => ['parameters]]]`
- * `assign` - Singular form of addAssignments, but only assigns a single column value
- * `assignSQL` - Assigns a column the value of a specified SQL expression without parameters
+ * [`assign()`](api:SilverStripe\ORM\Queries\SQLWriteExpression::assign()) - Singular form of `addAssignments()`, but only assigns a single column value
+ * [`assignSQL()`](api:SilverStripe\ORM\Queries\SQLWriteExpression::assignSQL()) - Assigns a column the value of a specified SQL expression without parameters -
    `assignSQL('Column', 'SQL')` is shorthand for `assign('Column', ['SQL' => []])`
 
-SQLUpdate also includes the following API methods:
+`SQLUpdate` also includes the following API methods:
 
- * `clear` - Clears all assignments
- * `getTable` - Gets the table to update
- * `setTable` - Sets the table to update (this should be ANSI-quoted)
-   e.g. `$query->setTable('"SiteTree"');`
+ * [`clear()`](api:SilverStripe\ORM\Queries\SQLUpdate::clear()) - Clears all assignments
+ * [`getTable()`](api:SilverStripe\ORM\Queries\SQLUpdate::getTable()) - Gets the table to update
+ * [`setTable()`](api:SilverStripe\ORM\Queries\SQLUpdate::setTable()) - Sets the table to update (this should be ANSI-quoted)
+   e.g. `$query->setTable('"Page"');`
 
-SQLInsert also includes the following API methods:
- * `clear` - Clears all rows
- * `clearRow` - Clears all assignments on the current row
- * `addRow` - Adds another row of assignments, and sets the current row to the new row
- * `addRows` - Adds a number of arrays, each representing a list of assignment rows,
+`SQLInsert` also includes the following API methods:
+
+ * [`clear()`](api:SilverStripe\ORM\Queries\SQLInsert::clear()) - Clears all rows
+ * [`clearRow()`](api:SilverStripe\ORM\Queries\SQLInsert::clearRow()) - Clears all assignments on the current row
+ * [`addRow()`](api:SilverStripe\ORM\Queries\SQLInsert::addRow()) - Adds another row of assignments, and sets the current row to the new row
+ * [`addRows()`](api:SilverStripe\ORM\Queries\SQLInsert::addRows()) - Adds a number of arrays, each representing a list of assignment rows,
    and sets the current row to the last one
- * `getColumns` - Gets the names of all distinct columns assigned
- * `getInto` - Gets the table to insert into
- * `setInto` - Sets the table to insert into (this should be ANSI-quoted),
-   e.g. `$query->setInto('"SiteTree"');`
+ * [`getColumns()`](api:SilverStripe\ORM\Queries\SQLInsert::getColumns()) - Gets the names of all distinct columns assigned
+ * [`getInto()`](api:SilverStripe\ORM\Queries\SQLInsert::getInto()) - Gets the table to insert into
+ * [`setInto()`](api:SilverStripe\ORM\Queries\SQLInsert::setInto()) - Sets the table to insert into (this should be ANSI-quoted),
+   e.g. `$query->setInto('"Page"');`
 
 E.g.:
 
 ```php
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
 use SilverStripe\ORM\Queries\SQLUpdate;
 
-$update = SQLUpdate::create('"SiteTree"')->addWhere(['ID' => 3]);
+$schema = DataObject::getSchema();
+$siteTreeTable = DB::get_conn()->escapeIdentifier($schema->baseDataTable(SiteTree::class));
+
+$update = SQLUpdate::create($siteTreeTable)->addWhere(['"ID"' => 3]);
 
 // assigning a list of items
 $update->addAssignments([
@@ -200,19 +248,24 @@ $update->assignSQL('"Date"', 'NOW()');
 $update->execute();
 ```
 
-In addition to assigning values, the SQLInsert object also supports multi-row 
+In addition to assigning values, the `SQLInsert` object also supports multi-row
 inserts. For database connectors and API that don't have multi-row insert support
 these are translated internally as multiple single row inserts.
 
 For example:
 
 ```php
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
 use SilverStripe\ORM\Queries\SQLInsert;
 
-$insert = SQLInsert::create('"SiteTree"');
+$schema = DataObject::getSchema();
+$siteTreeTable = DB::get_conn()->escapeIdentifier($schema->baseDataTable(SiteTree::class));
 
-// Add multiple rows in a single call. Note that column names do not need 
-// to be symmetric
+$insert = SQLInsert::create($siteTreeTable);
+
+// Add multiple rows in a single call. Note that column names do not need to be symmetric
 $insert->addRows([
     ['"Title"' => 'Home', '"Content"' => '<p>This is our home page</p>'],
     ['"Title"' => 'About Us', '"ClassName"' => 'AboutPage']
@@ -224,8 +277,8 @@ $insert->assign('"Content"', '<p>This is about us</p>');
 // Add another row
 $insert->addRow(['"Title"' => 'Contact Us']);
 
-$columns = $insert->getColumns();
 // $columns will be ['"Title"', '"Content"', '"ClassName"'];
+$columns = $insert->getColumns();
 
 $insert->execute();
 ```
@@ -238,13 +291,22 @@ e.g. when you want a single column rather than a full-blown object representatio
 Example: Get the count from a relationship.
 
 ```php
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
 use SilverStripe\ORM\Queries\SQLSelect;
 
+$schema = DataObject::getSchema();
+$playerTableName = DB::get_conn()->escapeIdentifier($schema->baseDataTable(Player::class));
+$teamTableName = DB::get_conn()->escapeIdentifier($schema->baseDataTable(Team::class));
+$playerIdField = $schema->sqlColumnForField(Player::class, 'ID');
+$playerTeamIdField = $schema->sqlColumnForField(Player::class, 'TeamID');
+$teamIdField = $schema->sqlColumnForField(Team::class, 'ID');
+
 $sqlQuery = new SQLSelect();
-$sqlQuery->setFrom('Player');
-$sqlQuery->addSelect('COUNT("Player"."ID")');
-$sqlQuery->addWhere(['"Team"."ID"' => 99]);
-$sqlQuery->addLeftJoin('Team', '"Team"."ID" = "Player"."TeamID"');
+$sqlQuery->setFrom($playerTableName);
+$sqlQuery->addSelect('COUNT(' . $playerIdField . ')');
+$sqlQuery->addWhere([$teamIdField => 99]);
+$sqlQuery->addLeftJoin('Team', $teamIdField ' = ' . $playerTeamIdField);
 $count = $sqlQuery->execute()->value();
 ```
 
@@ -254,6 +316,104 @@ Note that in the ORM, this call would be executed in an efficient manner as well
 $count = $myTeam->Players()->count();
 ```
 
+### Value placeholders
+
+In some of the examples here you will have noticed a `?` as part of the query, which is a placeholder for a value. This is called a "parameterized" or "prepared" query and is a good way to make sure your values are correctly escaped automatically to help protect yourself against SQL injection attacks.
+
+With some queries you'll know ahead of time how many values you're including in your query, but sometimes (most notably when using the `IN` SQL operator) you will have a lot of values or a variable number of values and it can be difficult to get the correct number of `?` placeholders.
+
+In those cases, you can use the [`DB::placeholders()`](api:SilverStripe\ORM\DB::placeholders()) method, which prepares these placeholders for you.
+
+[info]
+If you need this for some thing other than inclusion in an `IN` SQL operation, you can pass a custom delimiter as the second argument to `DB::placeholders()`.
+
+Also note that you can pass an integer in as the first argument rather than an array of values, if you want.
+[/info]
+
+Example: Get the fields for all players in a team which has more than 15 wins.
+
+```php
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\Queries\SQLSelect;
+
+$schema = DataObject::getSchema();
+$playerTableName = DB::get_conn()->escapeIdentifier($schema->baseDataTable(Player::class));
+
+$teamIds = Team::get()->filter('Wins:GreaterThan', 15)->column('ID');
+$placeholders = DB::placeholders($teamIds);
+
+$sqlQuery = new SQLSelect();
+$sqlQuery->setFrom($playerTableName)->where([
+    $schema->sqlColumnForField(Player::class, 'ID') . ' in (' . $placeholders . ')' => $ids
+]);
+$results = $sqlQuery->execute();
+```
+
+[info]
+This is obviously a contrived example - this could easily (and more efficiently) be done using the ORM:
+
+```php
+$players = Player::get()->filter('Teams.Wins:GreaterThan', 15);
+```
+[/info]
+
+### Joining tables for a DataObject inheritance chain {#joins-for-inheritance}
+
+In the [Introduction to the Data Model and ORM](data_model_and_orm/#subclasses) we discussed how `DataObject` inheretance chains can spread their data across multiple tables. The ORM handles this seemlessly, but when using the lower-level APIs we need to account for this ourselves by joining all of the relevant tables manually.
+
+We also want to make sure to _only_ select the records which are relevant for the actual class in the class hierarchy we're looking at. To do that, we can either use an `INNER JOIN`, or we can use a `WHERE` clause on the `ClassName` field. In the below example we're using a `WHERE` clause with a `LEFT JOIN` because it is likely more intuitive for developers who aren't intimately familar with SQL.
+
+```php
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\Queries\SQLSelect;
+
+$schema = DataObject::getSchema();
+$computerBaseTable = DB::get_conn()->escapeIdentifier($schema->baseDataTable(Computer::class));
+
+$select = new SQLSelect();
+$select->setFrom($computerTable);
+$select->addWhere([$schema->sqlColumnForField(Computer::class, 'ClassName') => Computer::class]);
+
+// Get all fields included in the query
+$columns = $select->getSelect();
+// If we're doing a "SELECT *" (which is the default select), get the field names from the DataObjectSchema instead
+if (count($columns) === 1 && array_key_first($columns) === '*') {
+    $columns = $schema->fieldSpecs(Computer::class);
+}
+
+// Make sure we join all the tables in the inheritance chain which are required for this query
+foreach ($columns as $alias => $ansiQuotedColumn) {
+    if ($schema->fieldSpec(Computer::class, $alias, DataObjectSchema::DB_ONLY)) {
+        $fieldTable = $schema->tableForField(Computer::class, $alias);
+        if (!$select->isJoinedTo($fieldTable)) {
+            $quotedFieldTable = DB::get_conn()->escapeIdentifier($fieldTable);
+            $joinOnClause = $schema->sqlColumnForField(Computer::class, 'ID') . ' = ' . $quotedFieldTable . '."ID"';
+            $select->addLeftJoin($quotedFieldTable, $joinOnClause);
+        }
+    }
+}
+```
+
+[hint]
+If we want all of the fields for _all_ models in the class hierarchy (mimicking `Product::get()` where `Product` is the first subclass of `DataObject` - see the example in the [Introduction to the Data Model and ORM](data_model_and_orm/#subclasses)), we can do this by using a `LEFT JOIN` (like above), ommitting the `WHERE` clause on the `ClassName` field, and making sure we join _all_ tables for the inheritance chain regardless of the fields being selected. To do that, make sure you're using the first `DataObject` class as your first main query class (replace `Computer` above with `Product`, in this example), remove the call to `$select->addWhere()`, and add the following code to the end of the above example:
+
+```php
+// Make sure we join all the tables for the model inheritance chain
+foreach (ClassInfo::subclassesFor(Product::class, includeBaseClass: false) as $class) {
+    if ($schema->classHasTable($class)) {
+        $classTable = $schema->tableName($class);
+        if (!$select->isJoinedTo($classTable)) {
+            $quotedClassTable = DB::get_conn()->escapeIdentifier($classTable);
+            $joinOnClause = $schema->sqlColumnForField(Product::class, 'ID') . ' = ' . $quotedClassTable . '."ID"';
+            $select->addLeftJoin($quotedClassTable, $joinOnClause);
+        }
+    }
+}
+```
+[/hint]
+
 ### Mapping
 
 Creates a map based on the first two columns of the query result. 
@@ -262,19 +422,26 @@ This can be useful for creating dropdowns.
 Example: Show player names with their birth year, but set their birth dates as values.
 
 ```php
-use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\Forms\DropdownField;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\Queries\SQLSelect;
+
+$schema = DataObject::getSchema();
+$playerTableName = DB::get_conn()->escapeIdentifier($schema->baseDataTable(Player::class));
 
 $sqlQuery = new SQLSelect();
-$sqlQuery->setFrom('Player');
-$sqlQuery->setSelect('Birthdate');
-$sqlQuery->selectField('CONCAT("Name", ' - ', YEAR("Birthdate")', 'NameWithBirthyear');
+$sqlQuery->setFrom($playerTableName);
+$sqlQuery->setSelect('"ID"');
+$sqlQuery->selectField('CONCAT("Name", \' - \', YEAR("Birthdate")', 'NameWithBirthyear');
 $map = $sqlQuery->execute()->map();
+
+// The value of the selected option will be the record ID, and the display label will be the name and birthyear concatenation.
 $field = new DropdownField('Birthdates', 'Birthdates', $map);
 ```
 
-Note that going through SQLSelect is just necessary here 
-because of the custom SQL value transformation (`YEAR()`). 
+Note that going through `SQLSelect` is only necessary here
+because of the custom SQL value transformation (`YEAR()`).
 An alternative approach would be a custom getter in the object definition:
 
 ```php
@@ -286,13 +453,44 @@ class Player extends DataObject
         'Name' =>  'Varchar',
         'Birthdate' => 'Date'
     ];
-    function getNameWithBirthyear() {
+
+    public function getNameWithBirthyear()
+    {
         return date('y', $this->Birthdate);
     }
 }
-$players = Player::get();
-$map = $players->map('Name', 'NameWithBirthyear');
+
+$map = Player::get()->map('ID', 'NameWithBirthyear');
 ```
+
+### True raw SQL
+
+Up until now we've still been using an abstraction layer to perform SQL queries - but there might be times where it's just cleaner to explicitly use raw SQL. You can do that with either the [`DB::query()`](api:SilverStripe\ORM\DB::query()) or [`DB::prepared_query()`](api:SilverStripe\ORM\DB::prepared_query()) method.
+
+Directly querying the database:
+
+```php
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+
+$schema = DataObject::getSchema();
+$siteTreeBaseTable = DB::get_conn()->escapeIdentifier($schema->baseDataTable(SiteTree::class));
+$showInMenusField = $schema->sqlColumnForField(SiteTree::class, 'ShowInMenus');
+
+// Use DB::query() if you don't need to pass in any parameters (values)
+$count = DB::query('SELECT COUNT(*) FROM ' . $siteTreeBaseTable)->value();
+
+// Use DB::prepared_query() if you need to pass in some parameters (values) e.g. for WHERE clauses
+$results = DB::prepared_query('DELETE FROM ' . $siteTreeBaseTable . ' WHERE ' . $showInMenusField . ' = ?', [0]);
+foreach ($results as $row) {
+    // $row is an array representing the database row, just like with SQLSelect.
+}
+```
+
+[hint]
+Note that you do _not_ have to call `execute()` with these methods, unlike the abstraction layer in the other examples. This is because you're passing the entire query into the method - you can't change the query after it's passed in, so it gets executed right away. The return type for these methods is the same as the return type for the [`execute()`](api::SilverStripe\ORM\Queries\SQLExpression::execute()) methods on the `SQLExpression` classes.
+[/hint]
 
 ### Data types
 

--- a/en/02_Developer_Guides/00_Model/09_Validation.md
+++ b/en/02_Developer_Guides/00_Model/09_Validation.md
@@ -6,23 +6,23 @@ icon: check-square
 
 # Validation and Constraints
 
-Traditionally, validation in Silverstripe CMS has been mostly handled on the controller through [form validation](../forms).
+Traditionally, validation in Silverstripe CMS has been mostly handled through [form validation](../forms).
 
-While this is a useful approach, it can lead to data inconsistencies if the record is modified outside of the 
-controller and form context.
+While this is a useful approach, it can lead to data inconsistencies if the record is modified outside of the form context.
 
-Most validation constraints are actually data constraints which belong on the model. Silverstripe CMS provides the 
-[DataObject::validate()](api:SilverStripe\ORM\DataObject::validate()) method for this purpose.
+Most validation constraints are actually data constraints which belong on the model. Silverstripe CMS provides the
+[DataObject::validate()](api:SilverStripe\ORM\DataObject::validate()) method for this purpose. The `validate()` method is
+called any time the `write()` method is called, before the `onBeforeWrite()` extension hook.
 
-By default, there is no validation - objects are always valid! However, you can overload this method in your DataObject 
-sub-classes to specify custom validation, or use the `validate` hook through a [DataExtension](api:SilverStripe\ORM\DataExtension).
+By default, there is no validation - objects are always valid! However, you can override this method in your `DataObject`
+sub-classes to specify custom validation, or use the `validate()` extension hook through an [Extension](api:SilverStripe\Core\Extension).
 
-Invalid objects won't be able to be written - a [ValidationException](api:SilverStripe\ORM\ValidationException) will be thrown and no write will occur.
+Invalid objects won't be able to be written - a [`ValidationException`](api:SilverStripe\ORM\ValidationException) will be thrown and no write will occur.
 
-It is expected that you call `validate()` in your own application to test that an object is valid before attempting a 
+Ideally you should call `validate()` in your own application to test that an object is valid before attempting a
 write, and respond appropriately if it isn't.
 
-The return value of `validate()` is a [ValidationResult](api:SilverStripe\ORM\ValidationResult) object.
+The return value of `validate()` is a [`ValidationResult`](api:SilverStripe\ORM\ValidationResult) object.
 
 ```php
 use SilverStripe\ORM\DataObject;

--- a/en/02_Developer_Guides/00_Model/11_Scaffolding.md
+++ b/en/02_Developer_Guides/00_Model/11_Scaffolding.md
@@ -13,7 +13,7 @@ customise those fields as required.
 
 ## Form Fields
 
-An example is `DataObject`, Silverstripe CMS will automatically create your CMS interface so you can modify what you need.
+An example is `DataObject`, Silverstripe CMS will automatically create your CMS interface so you can modify what you need, without having to define all of your form fields from scratch.
 
 ```php
 use SilverStripe\ORM\DataObject;
@@ -37,6 +37,10 @@ class MyDataObject extends DataObject
 }
 ```
 
+[hint]
+It is typically considered a good practice to wrap your modifications in a call to [`beforeUpdateCMSFields()`](api:SilverStripe\ORM\DataObject::beforeUpdateCMSFields()) - the `updateCMSFields()` extension hook is already triggered by `parent::getCMSFields()`, so this is how you ensure any new fields are added before extensions update your fieldlist.
+[/hint]
+
 To fully customise your form fields, start with an empty FieldList.
 
 ```php
@@ -52,13 +56,18 @@ public function getCMSFields()
             )
         )
     );
+
+    $this->extend('updateCMSFields', $fields);
     
     return $fields;
 }
 ```
 
-You can also alter the fields of built-in and module `DataObject` classes through your own 
-[DataExtension](/developer_guides/extending/extensions), and a call to `DataExtension->updateCMSFields`.
+[hint]
+It is good practice to invoke the `updateCMSFields()` extension hook afterward, so that extensions in modules can apply their functionality to your field list.
+[/hint]
+
+You can also alter the fields of built-in and module `DataObject` classes by implementing `updateCMSFields()` in [your own Extension](/developer_guides/extending/extensions).
 
 [info]
 `FormField` scaffolding takes [`$field_labels` config](#field-labels) into account as well.
@@ -89,7 +98,7 @@ class MyDataObject extends DataObject
 
 ### General search field
 
-Tabular views such as `GridField` or `ModalAdmin` include a search bar. The search bar will search across all of your searchable fields by default. It will return a match if the search terms appear in any of the searchable fields.
+Tabular views such as `GridField` or `ModelAdmin` include a search bar. The search bar will search across all of your searchable fields by default. It will return a match if the search terms appear in any of the searchable fields.
 
 #### Exclude fields from the general search
 
@@ -315,10 +324,10 @@ class Player extends DataObject
 
 ### Searching many db fields on a single search field
 
-Use a single search field that matches on multiple database fields with `'match_any'`. This also supports specifying a field and a filter, though it is not necessary to do so.
+Use a single search field that matches on multiple database fields with `'match_any'`. This also supports specifying a `FormField` and a filter, though it is not necessary to do so.
 
 [alert]
-If you don't specify a field, you must use the name of a real database field instead of a custom name so that a default field can be determined.
+If you don't specify a `FormField`, you must use the name of a real database field as the array key instead of a custom name so that a default field class can be determined.
 [/alert]
 
 ```php
@@ -435,6 +444,8 @@ class MyDataObject extends DataObject
 In order to re-label any summary fields, you can use the `$field_labels` static. This will also affect the output of `$object->fieldLabels()` and `$object->fieldLabel()`.
 
 ```php
+namespace App\Model;
+
 use SilverStripe\ORM\DataObject;
 
 class MyDataObject extends DataObject
@@ -444,7 +455,7 @@ class MyDataObject extends DataObject
     ];
     
     private static $has_one = [
-        'HeroImage' => 'Image',
+        'HeroImage' => Image::class,
     ];
     
     private static $summary_fields = [
@@ -458,6 +469,45 @@ class MyDataObject extends DataObject
     ];
 }
 ```
+
+### Localisation {#field-label-localisation}
+
+For any fields _not_ defined in `$field_labels`, labels can be localised by defining the name prefixed by the type of field (e.g `db_`, `has_one_`, etc) in your localisation yaml files:
+
+[info]
+The class name should be the class that defined the field or relationship.
+[/info]
+
+**`app/lang/en.yml`**
+
+```yml
+en:
+  App\Model\MyDataObject:
+    db_Name: "Name"
+    has_one_HeroImage: "Hero Image"
+```
+
+[notice]
+For relations (such as `has_one_HeroImage` above), this field label applies to the scaffolded form field (an `UploadField` for files, a tab for `has_many`/`many_many`, etc). It does _not_ apply to summary or searchable fields with dot notation.
+[/notice]
+
+Labels you define in `$field_labels` _won't_ be overridden by localisation strings. To make those localisable, you will need to override the [`fieldLabels()`](api:SilverStripe\ORM\DataObject) method and explicitly localise those labels yourself:
+
+```php
+public function fieldLabels($includerelations = true)
+{
+    $labels = parent::fieldLabels($includerelations);
+    $customLabels = static::config()->get('field_labels');
+
+    foreach ($customLabels as $name => $label) {
+        $labels[$name] = _t(__CLASS__ . '.' . $name, $label);
+    }
+
+    return $labels;
+}
+```
+
+See the [i18n section](/developer_guides/i18n) for more about localisation.
 
 ## Related Documentation
 

--- a/en/02_Developer_Guides/00_Model/12_Indexes.md
+++ b/en/02_Developer_Guides/00_Model/12_Indexes.md
@@ -22,9 +22,10 @@ The Silverstripe CMS framework already places certain indexes for you by default
 - The `ClassName` column if your model inherits from `DataObject`
 - All relationships defined in the model have indexes for their `has_one` entity (for `many_many` relationships 
 this index is present on the associative entity).
+- All fields used in `default_sort` configuration
 
 ## Defining an index
-Indexes are represented on a `DataObject` through the `DataObject::$indexes` array which maps index names to a 
+Indexes are represented on a `DataObject` through the `DataObject.indexes` configuration property which maps index names to a 
 descriptor. There are several supported notations:
 
 ```php
@@ -72,11 +73,6 @@ class MyTestObject extends DataObject
 }
 ```
 
-[alert]
-Please note that if you have previously used the removed `value` key to define an index's contents, Silverstripe CMS will
-now throw an error. Use `columns` instead.
-[/alert]
-
 ## Complex/Composite Indexes
 For complex queries it may be necessary to define a complex or composite index on the supporting object. To create a 
 composite index, define the fields in the index order as a comma separated list. 
@@ -95,9 +91,6 @@ other columns. If this is indexed, smaller and reasonably unique it might be fas
 ## Index Creation/Destruction
 Indexes are generated and removed automatically during a `dev/build`. Caution if you're working with large tables and 
 modify an index as the next `dev/build` will `DROP` the index, and then `ADD` it. 
-
-Note that `default_sort` fields automatically become database indexes as this provides significant performance
-benefits.
 
 ## API Documentation
 

--- a/en/02_Developer_Guides/00_Model/How_Tos/Grouping_DataObject_Sets.md
+++ b/en/02_Developer_Guides/00_Model/How_Tos/Grouping_DataObject_Sets.md
@@ -10,10 +10,10 @@ These lists can get quite long, and hard to present on a single list.
 [Pagination](/developer_guides/templates/how_tos/pagination) is one way to solve this problem,
 by splitting up the list into multiple pages.
 
-In this howto, we present an alternative to pagination: 
-Grouping a list by various criteria, through the [GroupedList](api:SilverStripe\ORM\GroupedList) class.
+In this howto, we present an alternative to pagination:
+grouping a list by various criteria, through the [GroupedList](api:SilverStripe\ORM\GroupedList) class.
 This class is a [ListDecorator](api:SilverStripe\ORM\ListDecorator), which means it wraps around a list,
-adding new functionality. 
+adding new functionality.
 
 It provides a `groupBy()` method, which takes a field name, and breaks up the managed list 
 into a number of arrays, where each array contains only objects with the same value of that field. 
@@ -79,6 +79,10 @@ class Page extends SiteTree
 }
 ```
 
+[notice]
+Notice that we're sorting as part of the ORM call. While `GroupedList` does have a `sort()` method, it doesn't work how you might expect, as it returns a sorted copy of the underlying list rather than sorting the list in place.
+[/notice]
+
 The final step is to render this into a template. The `GroupedBy()` method breaks up the set into
 a number of sets, grouped by the field that is passed as the parameter. 
 In this case, the `getTitleFirstLetter()` method defined earlier is used to break them up.
@@ -86,7 +90,7 @@ In this case, the `getTitleFirstLetter()` method defined earlier is used to brea
 ```ss
 <%-- Modules list grouped by TitleFirstLetter --%>
 <h2>Modules</h2>
-<% loop $GroupedModules.GroupedBy(TitleFirstLetter) %>
+<% loop $GroupedModules.GroupedBy("TitleFirstLetter") %>
     <h3>$TitleFirstLetter</h3>
     <ul>
         <% loop $Children %>
@@ -143,12 +147,13 @@ class Page extends SiteTree
     }
 }
 ```
+
 The final step is to render this into the template using the [GroupedList::GroupedBy()](api:SilverStripe\ORM\GroupedList::GroupedBy()) method.
 
 ```ss
-// Modules list grouped by the Month Posted
+<%-- Modules list grouped by the Month Posted --%>
 <h2>Modules</h2>
-<% loop $GroupedModulesByDate.GroupedBy(MonthCreated) %>
+<% loop $GroupedModulesByDate.GroupedBy("MonthCreated") %>
     <h3>$MonthCreated</h3>
     <ul>
         <% loop $Children %>

--- a/en/02_Developer_Guides/00_Model/index.md
+++ b/en/02_Developer_Guides/00_Model/index.md
@@ -5,9 +5,9 @@ introduction: This guide will cover how to create and manipulate data within Sil
 icon: database
 ---
 
-In Silverstripe CMS, application data will be represented by a [DataObject](api:SilverStripe\ORM\DataObject) class. A `DataObject` subclass defines the
-data columns, relationships and properties of a particular data record. For example, [Member](api:SilverStripe\Security\Member) is a `DataObject` 
-which stores information about a person, CMS user or mail subscriber.
+In Silverstripe CMS, application data is typically represented by [`DataObject`](api:SilverStripe\ORM\DataObject) models. A `DataObject` subclass defines the
+data columns, relationships and properties of a particular data record. For example, [`Member`](api:SilverStripe\Security\Member) is a `DataObject` 
+which stores information about a person who has authenticated access to your project.
 
 [CHILDREN Exclude="How_tos"]
 

--- a/en/02_Developer_Guides/05_Extending/01_Extensions.md
+++ b/en/02_Developer_Guides/05_Extending/01_Extensions.md
@@ -321,7 +321,7 @@ public function getCMSFields()
 
 ## Extending extensions {#extendingextensions}
 
-Extension classes can be overloaded using the Injector, if you want to modify the way that an extension in one of
+Extension classes can be overridden using the Injector, if you want to modify the way that an extension in one of
 your modules works:
 
 ```yaml

--- a/en/02_Developer_Guides/08_Performance/01_Caching.md
+++ b/en/02_Developer_Guides/08_Performance/01_Caching.md
@@ -57,7 +57,7 @@ any content written to the cache in the _draft_ reading mode isn’t accidentall
 Please read the [versioned cache segmentation](#versioned-cache-segmentation) section for more information.
 [/alert]
 
-Cache objects are instantiated through a [CacheFactory](SilverStripe\Core\Cache\CacheFactory),
+Cache objects are instantiated through a [CacheFactory](api:SilverStripe\Core\Cache\CacheFactory),
 which determines which cache adapter is used (see "Adapters" below for details).
 This factory allows us you to globally define an adapter for all cache instances.  
 

--- a/en/02_Developer_Guides/09_Security/00_Member.md
+++ b/en/02_Developer_Guides/09_Security/00_Member.md
@@ -59,9 +59,9 @@ SilverStripe\Core\Injector\Injector:
 
 Note that if you want to look this class-name up, you can call `Injector::inst()->get('Member')->ClassName`
 
-## Overloading getCMSFields()
+## Overriding getCMSFields()
 
-If you overload the built-in public function getCMSFields(), then you can change the form that is used to view & edit member
+If you override the built-in public function getCMSFields(), then you can change the form that is used to view & edit member
 details in the newsletter system.  This function returns a [FieldList](api:SilverStripe\Forms\FieldList) object.  You should generally start by calling
 parent::getCMSFields() and manipulate the [FieldList](api:SilverStripe\Forms\FieldList) from there.
 

--- a/en/02_Developer_Guides/12_Search/01_Searchcontext.md
+++ b/en/02_Developer_Guides/12_Search/01_Searchcontext.md
@@ -89,7 +89,7 @@ the `$fields` constructor parameter.
 
 ### Customising the general search field
 
-On tabular views like the GridFields and ModalAdmins, the search context is rendered as a search bar
+On tabular views like the GridFields and ModelAdmins, the search context is rendered as a search bar
 with advanced options. To customise this field, see the [Scaffolding documentation](../model/scaffolding#general-search-field).
 
 ### Generating a search form from the context

--- a/en/02_Developer_Guides/14_Files/01_File_Management.md
+++ b/en/02_Developer_Guides/14_Files/01_File_Management.md
@@ -257,11 +257,11 @@ See [Versioned: Ownership](/developer_guides/model/versioning#ownership) for det
 
 ### Avoid exclusive relationships
 
-Due to the shared nature of assets, it is not recommended to assign any 1-to-many (or exclusive 1-to-1) relationship
+Due to the shared nature of assets, it is not recommended to assign any one-to-many (or exclusive one-to-one) relationship
 between any objects and a File. E.g. a Page has_many File, or Page belongs_to File.
 
 
-Instead it is recommended to use either a Page has_one File for many-to-1 (or 1-to-1) relationships, or
+Instead it is recommended to use either a Page has_one File for many-to-one (or one-to-one) relationships, or
 Page many_many File for many-to-many relationships.
 
 ### Unpublishing assets

--- a/en/02_Developer_Guides/15_Customising_the_Admin_Interface/01_ModelAdmin.md
+++ b/en/02_Developer_Guides/15_Customising_the_Admin_Interface/01_ModelAdmin.md
@@ -371,7 +371,7 @@ If you wish to provided a tailored esperience for CMS users, you can directly in
 
 Extensions applied to a ModelAdmin can also use the `updateGridField` and `updateGridFieldConfig` hooks.
 
-To alter how the results are displayed (via [GridField](api:SilverStripe\Forms\GridField\GridField)), you can also overload the `getEditForm()` method. For
+To alter how the results are displayed (via [GridField](api:SilverStripe\Forms\GridField\GridField)), you can also override the `getEditForm()` method. For
 example, to add a new component.
 
 ### Overriding the methods on ModelAdmin

--- a/en/02_Developer_Guides/15_Customising_the_Admin_Interface/02_CMS_Architecture.md
+++ b/en/02_Developer_Guides/15_Customising_the_Admin_Interface/02_CMS_Architecture.md
@@ -140,14 +140,14 @@ In case you want to retain the main CMS structure (which is recommended),
 just create your own "Content" template (e.g. `MyCMSController_Content.ss`),
 which is in charge of rendering the main content area apart from the CMS menu.
 
-Depending on the complexity of your layout, you'll also need to overload the
+Depending on the complexity of your layout, you'll also need to override the
 "EditForm" template (e.g. `MyCMSController_EditForm.ss`), e.g. to implement
 a tabbed form which only scrolls the main tab areas, while keeping the buttons at the bottom of the frame.
 This requires manual assignment of the template to your form instance, see [CMSMain::getEditForm()](api:SilverStripe\CMS\Controllers\CMSMain::getEditForm()) for details.
 
 Often its useful to have a "tools" panel in between the menu and your content,
 usually occupied by a search form or navigational helper.
-In this case, you can either overload the full base template as described above.
+In this case, you can either override the full base template as described above.
 To avoid duplicating all this template code, you can also use the special [LeftAndMain::Tools()](api:SilverStripe\Admin\LeftAndMain::Tools()) and
 [LeftAndMain::EditFormTools()](api:SilverStripe\Admin\LeftAndMain::EditFormTools()) methods available in `LeftAndMain`.
 These placeholders are populated by auto-detected templates,

--- a/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/Extend_CMS_Interface.md
+++ b/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/Extend_CMS_Interface.md
@@ -18,7 +18,7 @@ simple checkbox.
 For a deeper introduction to the inner workings of the CMS, please refer to our
 guide on [CMS Architecture](/developer_guides/customising_the_admin_interface/cms_architecture).
 
-## Overload a CMS template
+## Override a CMS template
 
 If you place a template with an identical name into your application template
 directory (usually `app/templates/`), it'll take priority over the built-in

--- a/en/04_Changelogs/alpha/5.0.0-alpha1.md
+++ b/en/04_Changelogs/alpha/5.0.0-alpha1.md
@@ -140,7 +140,7 @@ This is an alpha of a major release and as a result there are a number of breaki
 - Prior to 5.0.0, when using `SQLSelect::setFrom()` or `SQLSelect::create('*', $from)` to set table or subselect definitions,
 their aliases (applied by setting a string key for the array) were being ignored. This bug has been fixed - if you were working around this by manually setting the alias e.g. in a join, you can remove those workarounds now.
 - [Query](api:SilverStripe\ORM\Connect\Query) now implements `IteratorAggregate` instead of `Iterator`. This means `seek()` and other iterator methods are no longer available on this class and its subclasses. Use `getIterator()` instead.
-- [DataList](SilverStripe\ORM\DataList), its subclasses, [Map](api:SilverStripe\ORM\Map), and [ArrayList](SilverStripe\ORM\ArrayList) all now return generators from `getIterator()`. This reduces memory usage when looping over large result sets. As a result of this, `getGenerator()` has been removed as it is no longer needed. Note that `chunkedFetch()` has not been removed, as it may still be useful for very large result sets to fetch results in smaller chunks at a time.
+- [DataList](api:SilverStripe\ORM\DataList), its subclasses, [Map](api:SilverStripe\ORM\Map), and [ArrayList](api:SilverStripe\ORM\ArrayList) all now return generators from `getIterator()`. This reduces memory usage when looping over large result sets. As a result of this, `getGenerator()` has been removed as it is no longer needed. Note that `chunkedFetch()` has not been removed, as it may still be useful for very large result sets to fetch results in smaller chunks at a time.
 
 ## Dependency changes {#dependency-changes}
 
@@ -158,7 +158,7 @@ This empowers advanced `Extension` functionality such as [Versioned::canPublish(
 
 ### Other new features {#other-features}
 
-- [DataObject::get_one()][api:SilverStripe\ORM\DataObject::get_one()] can now be called directly from subclasses of `DataObject` without passing in a class as the first argument (e.g. `SiteTree::get_one(filter: ['Title:startsWith' => 'About'])`).
+- [DataObject::get_one()](api:SilverStripe\ORM\DataObject::get_one()) can now be called directly from subclasses of `DataObject` without passing in a class as the first argument (e.g. `SiteTree::get_one(filter: ['Title:startsWith' => 'About'])`).
 
 ## Bugfixes {#bugfixes}
 


### PR DESCRIPTION
A (relatively quick) sweep over the getting started and ORM sections of the docs to update any false or outdated information.

Note: This should be reviewed _after_ https://github.com/silverstripe/developer-docs/pull/188

## Scope
The primary purpose of this PR is to ensure that:
1. code examples actually work in CMS 5
2. written documentation is factually correct

In many cases I have also augmented the existing documentation to make it clearer or to add information I felt was missing.

There are also cases where I have updated code examples or written documentation to better reflect best practices - but that is _not_ the main purpose of this PR. If there are areas where I have not updated examples or docs to reflect best practices (but those examples work and the docs are factually correct) then they are _out of scope_ for this PR.

Formatting that I haven't explicitly touched is definitely out of scope.

## Issue
- https://github.com/silverstripe/developer-docs/issues/164