### PR TITLE
Fix html entities in notices

### DIFF
--- a/en/02_Developer_Guides/06_Testing/01_Functional_Testing.md
+++ b/en/02_Developer_Guides/06_Testing/01_Functional_Testing.md
@@ -110,7 +110,7 @@ selector will be applied to the HTML of the most recent page. The content of eve
 assertion fails if one of the expectedMatches fails to appear.
 
 [notice]
-`&amp;nbsp;` characters are stripped from the content; make sure that your assertions take this into account.
+`&nbsp;` characters are stripped from the content; make sure that your assertions take this into account.
 [/notice]
 
 ### assertExactHTMLMatchBySelector
@@ -125,7 +125,7 @@ selector will be applied to the HTML of the most recent page.  The full HTML of 
 assertion fails if one of the expectedMatches fails to appear.
 
 [notice]
-`&amp;nbsp;` characters are stripped from the content; make sure that your assertions take this into account.
+`&nbsp;` characters are stripped from the content; make sure that your assertions take this into account.
 [/notice]
 
 ## Related Documentation


### PR DESCRIPTION
It looks like the `&amp;` is not being converted to `&` when compiled, as it is being compiled into a `<code>` tag because of the `\``

<img width="444" alt="Screen Shot 2023-03-21 at 4 34 48 PM" src="https://user-images.githubusercontent.com/415374/226511900-498be2d3-ddfc-4c7e-bcd1-470abaca9883.png">

Should be safe to just include the `&nbsp;` raw.