### PR TITLE
DOC Add section on ORM performance

### DIFF
--- a/en/02_Developer_Guides/08_Performance/06_ORM.md
+++ b/en/02_Developer_Guides/08_Performance/06_ORM.md
@@ -1,0 +1,32 @@
+---
+title: ORM Performance
+summary: Configuration and tips for improving ORM performance
+---
+
+## ORM Performance
+
+### Indexes
+
+You can define indexes for your ORM queries using the `$indexes` configuration property in your `DataObject` subclasses. See the [Indexes](/developer_guides/model/indexes) section for more information.
+
+### Skipping check and repair during dev/build {#skip-check-and-repair}
+
+When you run `dev/build`, there is a step that checks the integrity of the database tables (via `CHECK TABLE`) and repairs issues (via `REPAIR TABLE`) if possible.
+
+For tables with many records (tens/hundreds of thousands) this can be slow. If you identify that you have some specific `DataObject` models with lots of records
+which are slowing down your `dev/build`, you might want to explicitly skip checks for those:
+
+```yml
+SilverStripe\ORM\Connect\DBSchemaManager:
+  exclude_models_from_db_checks:
+    - App\Model\ModelWithManyRecords
+```
+
+You can also disable these checks entirely:
+
+```yml
+SilverStripe\ORM\Connect\DBSchemaManager:
+  check_and_repair_on_build: false
+```
+
+You can always manually trigger a check and repair (e.g. in a [`BuildTask`](api:SilverStripe/Dev/BuildTask)) by calling [`DB::check_and_repair_table()`](api:SilverStripe\ORM\DB::check_and_repair_table()). This ignores the above configuration.

--- a/en/04_Changelogs/5.1.0.md
+++ b/en/04_Changelogs/5.1.0.md
@@ -1,0 +1,24 @@
+---
+title: 5.1.0 (unreleased)
+---
+
+# 5.1.0 (unreleased)
+
+## Overview
+
+- [Features and enhancements](#features-and-enhancements)
+  - [Other new features](#other-features)
+- [Bug fixes](#bug-fixes)
+
+## Features and enhancements
+
+### Other new features
+- You can now exclude specific `DataObject` models from the check and repair step of `dev/build` - see [ORM Performance](/developer_guides/performance/orm/#skip-check-and-repair) for more information.
+
+## Bug fixes
+
+This release includes a number of bug fixes to improve a broad range of areas. Check the change logs for full details of these fixes split by module. Thank you to the community members that helped contribute these fixes as part of the release!
+
+<!--- Changes below this line will be automatically regenerated -->
+
+<!--- Changes above this line will be automatically regenerated -->


### PR DESCRIPTION
This is just a couple of things for now - there are definitely more items that should be added here.

This section was mostly added because I needed a place to put the documentation for https://github.com/silverstripe/silverstripe-framework/pull/10746 - but I bet there are a ton of additional bits and bobs we can document here as well (such as https://github.com/silverstripe/silverstripe-framework/pull/10735 when it's merged)

I've [created a separate card](https://github.com/silverstripe/developer-docs/issues/202) to look for other items that should be documented here.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10495