### PR TITLE
DOC Update Controllers section

### DIFF
--- a/en/02_Developer_Guides/02_Controllers/03_Access_Control.md
+++ b/en/02_Developer_Guides/02_Controllers/03_Access_Control.md
@@ -11,7 +11,7 @@ actions on the website they shouldn't be able to.
 
 ## Allowed Actions
 
-Any action you define on a controller must be defined in a `$allowed_actions` static array. This prevents users from
+Any action you define on a controller must be defined in a `$allowed_actions` configuration array. This prevents users from
 directly calling methods that they shouldn't.
 
 ```php
@@ -19,7 +19,6 @@ use SilverStripe\Control\Controller;
 
 class MyController extends Controller 
 {
-    
     private static $allowed_actions = [
         // someaction can be accessed by anyone, any time
         'someaction', 
@@ -42,34 +41,55 @@ class MyController extends Controller
 }
 ```
 
+[notice]
+If you want to add access checks in a subclass for an action which is declared in a parent class, and the parent class _doesn't_ declare an access check for that action, your subclass will have to redeclare the action method.
+
+The declaration of the method can be as simple as:
+
+```php
+public function someAction(HTTPRequest $request)
+{
+    return parent::someAction($request);
+}
+```
+
+[/notice]
+
 [info]
 If the permission check fails, Silverstripe CMS will return a `403` Forbidden HTTP status.
 [/info]
 
-An action named "index" is white listed by default, unless `allowed_actions` is defined as an empty array, or the action 
+An action named "index" is allowed by default, unless `allowed_actions` is defined as an empty array, or the action
 is specifically restricted.
 
 ```php
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Controller;
  
 class MyController extends Controller 
 {
-
-    public function index() 
+    public function index(HTTPRequest $request) 
     {
-        // allowed without an $allowed_action defined
+        // allowed without being defined in $allowed_actions
     }
 }
 ```
 
-`$allowed_actions` can be defined on `Extension` classes applying to the controller.
+`$allowed_actions` can be defined on `Extension` classes applying to the controller:
+
+```yml
+Vendor\Module\Control\SomeModuleController:
+  extensions:
+    - 'App\Control\Extension\MyExtension'
+```
 
 ```php
+namespace App\Control\Extension;
+
 use SilverStripe\Core\Extension;
 
 class MyExtension extends Extension 
 {
-
     private static $allowed_actions = [
         'mycustomaction'
     ];
@@ -79,32 +99,32 @@ class MyExtension extends Extension
 Only public methods can be made accessible.
 
 ```php
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Controller;
 
 class MyController extends Controller 
 {
-
     private static $allowed_actions = [
         'secure',
-        // secureaction won't work as it's private.
+        // secureaction won't work as it's protected.
     ];
 
-    public function secure() 
+    public function secure(HTTPRequest $request) 
     {
         // ..
     }
 
-    private function secureaction() 
+    protected function secureaction() 
     {
         // ..
     }
 }
-
 ```
 
 If a method on a parent class is overwritten, access control for it has to be redefined as well.
 
 ```php
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Controller;
 
 class MyController extends Controller 
@@ -113,34 +133,29 @@ class MyController extends Controller
         'action',
     ];
 
-    public function action() 
+    public function action(HTTPRequest $request) 
     {
         // ..
     }
 }
+
 class MyChildController extends MyController 
 {
-
     private static $allowed_actions = [
-        'action', // required as we are redefining action
+        'action', // required as we are redefining the action
     ];
 
-    public function action() 
+    public function action(HTTPRequest $request) 
     {
 
     }
 }
-
 ```
-
-[notice]
-Access checks on parent classes need to be overwritten via the [Configuration API](../configuration).
-[/notice]
 
 ## Forms
 
 Form action methods should **not** be included in `$allowed_actions`. However, the form method **should** be included 
-as an `allowed_action`.
+as an allowed action.
 
 ```php
 use SilverStripe\Forms\Form;
@@ -163,8 +178,9 @@ class MyController extends Controller
         // ..
     }
 }
-
 ```
+
+See [the forms section](/developer_guides/forms/) for more information about handling routing for forms and their actions.
 
 ## Action Level Checks
 
@@ -172,40 +188,39 @@ Each method responding to a URL can also implement custom permission checks, e.g
 the passed request data.
 
 ```php
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Controller;
 
 class MyController extends Controller 
 {
-    
     private static $allowed_actions = [
         'myaction'
     ];
-    
-    public function myaction($request) 
+
+    public function myaction(HTTPRequest $request) 
     {
-        if(!$request->getVar('apikey')) {
+        if (!$request->getVar('apikey')) {
             return $this->httpError(403, 'No API key provided');
         } 
             
         return 'valid';
     }
 }
-
 ```
 
 [notice]
-This is recommended as an addition for `$allowed_actions`, in order to handle more complex checks, rather than a 
+This is recommended as an addition to access checks defined in `$allowed_actions`, in order to handle more complex checks, rather than a
 replacement.
 [/notice]
 
 ## Controller Level Checks
 
-After checking for allowed_actions, each controller invokes its `init()` method, which is typically used to set up 
-common state, If an `init()` method returns a `HTTPResponse` with either a 3xx or 4xx HTTP status code, it'll abort 
+After checking for allowed_actions, each controller invokes its [`init()`](api:SilverStripe\Control\Controller::init()) method, which is typically used to set up
+common state. If an `init()` method returns a `HTTPResponse` with either a 3xx or 4xx HTTP status code, it'll abort
 execution. This behavior can be used to implement permission checks.
 
 [info]
-`init` is called for any possible action on the controller and before any specific method such as `index`.
+`init()` is called regardless of the action that will ultimately handle the request, and executes before the action does.
 [/info]
 
 ```php
@@ -214,14 +229,12 @@ use SilverStripe\Control\Controller;
 
 class MyController extends Controller 
 {
-    
-    private static $allowed_actions = [];
-    
     public function init() 
     {
         parent::init();
 
-        if(!Permission::check('ADMIN')) {
+        // Only allow administrators to perform ANY action (including index) on this controller via HTTP requests
+        if (!Permission::check('ADMIN')) {
             return $this->httpError(403);
         }
     }

--- a/en/02_Developer_Guides/02_Controllers/04_Redirection.md
+++ b/en/02_Developer_Guides/02_Controllers/04_Redirection.md
@@ -11,19 +11,38 @@ HTTP header.
 
 **app/src/Page.php**
 
+```php
+// redirect to Page::goherenow(), i.e on the contact-us page this will redirect to /contact-us/goherenow/
+$this->redirect($this->Link('goherenow'));
+
+// redirect to the URL on www.example.com/goherenow/ assuming your website is hosted at www.example.com (note the leading slash)
+$this->redirect('/goherenow');
+
+// redirect to https://www.example.com (assuming that is an external website URL)
+$this->redirect('https://www.example.com');
+
+// go back to the previous page.
+$this->redirectBack();
+```
+
+## Back URL
+
+The `BackURL` get parameter is one mechanism the [`redirectBack()`](api:SilverStripe\Control\RequestHandler::redirectBack()) method uses to know where to redirect to. It also checks for a legacy `X-Backurl` header and a `referer` header, and failing that just redirects to the base URL for your website.
+
+You can use the `BackURL` parameter if you want an action to redirect users to some specific path. You might want to do this for example to force unauthenticated users to log in before performing an action.
 
 ```php
-$this->redirect($this->Link('goherenow'));
-// redirect to Page::goherenow(), i.e on the contact-us page this will redirect to /contact-us/goherenow/
+use SilverStripe\Control\Controller;
+use SilverStripe\Security\Security;
 
-$this->redirect('/goherenow');
-// redirect to the URL on www.example.com/goherenow/ assuming your website is hosted at www.example.com (note the leading slash)
+$args = ['BackURL' => $this->Link('someAction')];
+$this->redirect(Controller::join_links(Security::login_url(), '?' . http_build_query($args)));
+```
 
-$this->redirect('https://www.example.com');
-// redirect to https://www.example.com (assuming that is an external website URL)
+If there's already a `BackURL` parameter in the current request's URL, you can add that directly to any link:
 
-$this->redirectBack();
-// go back to the previous page.
+```php
+$linkWithBackURL = $this->addBackURLParam($this->Link('someAction'));
 ```
 
 ## Status Codes
@@ -32,22 +51,41 @@ The `redirect()` method takes an optional HTTP status code, either `301` for per
 temporary redirects (default).
 
 ```php
-$this->redirect('/', 302);
 // go back to the homepage, don't cache that this page has moved
+$this->redirect('/', 302);
 ```
 
-## Redirection in URL Handling
+## Redirections in routing rules
 
-Controllers can specify redirections in the `$url_handlers` property rather than defining a method by using the '~'
-operator.
+You can define redirections in the director routing rules. There are two ways to declare redirections in routing rules.
 
-```php
-private static $url_handlers = [
-    'players/john' => '~>coach'
-];
+If the routing rule pattern starts with `->`, it will be interpreted as a redirect.
+
+```yml
+SilverStripe\Control\Director:
+  rules:
+    'about': '->about-us'
 ```
 
-For more information on `$url_handlers` see the [Routing](routing) documentation.
+You can also explicitly declare the rule as a redirection using the following more explicit syntax, which can be a useful way to better visually distinguish redirection routes from controller routes.
+
+```yml
+SilverStripe\Control\Director:
+  rules:
+    'about':
+      Redirect: 'about-us'
+```
+
+The path to redirect to will be interpreted as being relative to your site root unless you explicitly set a protocol or prefix the URL with `//` like so:
+
+```yml
+SilverStripe\Control\Director:
+  rules:
+    'absolute-url1': '->//www.example.com'
+    'absolute-url2': '->https://www.example.com'
+```
+
+For more information about routing rules see the [Routing](routing) documentation.
 
 ## API Documentation
 

--- a/en/02_Developer_Guides/02_Controllers/05_Middlewares.md
+++ b/en/02_Developer_Guides/02_Controllers/05_Middlewares.md
@@ -8,18 +8,20 @@ summary: Create objects for modifying request and response objects across contro
 HTTP Middlewares allow you to add code that will run before or after a request has been delegated to the router. These might be used for
 authentication, logging, caching, request processing, and many other purposes.
 
-To create a middleware class, implement `SilverStripe\Control\Middleware\HTTPMiddleware` and define the
-`process(HTTPRequest $request, callable $delegate)` method. You can do anything you like in this
+To create a middleware class, implement [`HTTPMiddleware`](api:SilverStripe\Control\Middleware\HTTPMiddleware) and define the
+[`process()`](api:SilverStripe\Control\Middleware\HTTPMiddleware::process()) method. You can do anything you like in this
 method, but to continue normal execution, you should call `$response = $delegate($request)`
 at some point in this method.
 
-In addition, you should return an `HTTPResponse` object. In normal cases, this should be the
-`$response` object returned by `$delegate`, perhaps with some modification. However, sometimes you
+In addition, you should return an [`HTTPResponse`](api:SilverStripe\Control\HTTPResponse) object. In normal cases, this should be the
+value returned by `$delegate`, perhaps with some modification. However, sometimes you
 will deliberately return a different response, e.g. an error response or a redirection.
 
 **app/src/CustomMiddleware.php**
 
 ```php
+namespace App\Middleware;
+
 use SilverStripe\Control\Middleware\HTTPMiddleware;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
@@ -35,7 +37,7 @@ class CustomMiddleware implements HTTPMiddleware
             return new HTTPResponse('You missed the special header', 400);
         }
 
-        // You can modify the request before
+        // You can modify the request before passing it on to be processed
         // For example, this might force JSON responses
         $request->addHeader('Accept', 'application/json');
 
@@ -51,16 +53,14 @@ class CustomMiddleware implements HTTPMiddleware
 }
 ```
 
-Once you have created your middleware class, you must attach it to the `Director` config to make
+Once you have created your middleware class, you must attach it to the [`Director`](api:SilverStripe\Control\Director) using one of the below configuration options to make
 use of it.
 
 ## Global middleware
 
-By adding the service or class name to the `Director.Middlewares` property via injector,
-array, a middleware will be executed on every request:
+By adding the service or class name to the `Director->Middlewares` array property via injector, a middleware will be executed on every request:
 
 **app/_config/app.yml**
-
 
 ```yaml
 ---
@@ -72,9 +72,8 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Control\Director:
     properties:
       Middlewares:
-        CustomMiddleware: '%$CustomMiddleware'
+        CustomMiddleware: '%$App\Middleware\CustomMiddleware'
 ```
-
 
 Because these are service names, you can configure properties into a custom service if you would
 like:
@@ -88,15 +87,17 @@ SilverStripe\Core\Injector\Injector:
       Middlewares:
         CustomMiddleware: '%$ConfiguredMiddleware'
   ConfiguredMiddleware:
-   class: 'CustomMiddleware'
-   properties:
-     Secret: "DIFFERENT-ONE"
+    class: 'App\Middleware\CustomMiddleware'
+    properties:
+      Secret: "DIFFERENT-ONE"
 ```
+
+See [Dependency Injection](/developer_guides/extending/injector) for more information about the injector configuration syntax.
 
 ## Route-specific middleware
 
 Alternatively, you can apply middlewares to a specific route. These will be processed after the
-global middlewares. You can do this by using the `RequestHandlerMiddlewareAdapter` class
+global middlewares. You can do this by using the [`RequestHandlerMiddlewareAdapter`](api:SilverStripe\Control\Middleware\RequestHandlerMiddlewareAdapter) class
 as a replacement for your controller, and register it as a service with a `Middlewares`
 property. The controller which does the work should be registered under the
 `RequestHandler` property.
@@ -108,10 +109,11 @@ SilverStripe\Core\Injector\Injector:
   SpecialRouteMiddleware:
     class: SilverStripe\Control\Middleware\RequestHandlerMiddlewareAdapter
     properties:
-      RequestHandler: '%$MyController'
+      RequestHandler: '%$App\Control\MyController'
       Middlewares:
-        - '%$CustomMiddleware'
+        - '%$App\Middleware\CustomMiddleware'
         - '%$AnotherMiddleware'
+
 SilverStripe\Control\Director:
   rules:
     special/section:
@@ -124,8 +126,7 @@ Some use cases will require a middleware to run before the Silverstripe CMS has 
 the HTTPRequest before Silverstripe CMS routes it to a controller). This can be achieved by editing the Silverstripe 
 CMS entry point file.
 
-This file will be located in your own codebase at `public/index.php`, or directly in your project root at `index.php` 
-if your project doesn't use the public web root. Find the line that instantiate `HTTPApplication`. Call the 
+This file will be located in your own codebase at `public/index.php`. Find the line that instantiate `HTTPApplication`. Call the
 `addMiddleware` method on the `HTTPApplication` instance and pass it an instance of your middleware. This must be done
 before the request is handled.
 
@@ -140,17 +141,28 @@ $response = $app->handle($request);
 $response->output();
 ```
 
-Beware that by this point, the Silverstripe framework features you normally rely on won't be 
-available in your middleware or in `index.php` because they won't have been initialised yet. (e.g.: ORM, Injector, services configured by Injector)
+[info]
+It's pretty rare to need to modify the `index.php` file directly like this - if you need to do it, make sure you clearly document this change
+somewhere, e.g. in your project's README.md file if you have one, both for your own reference and for any other developers working on the project
+with you.
+[/info]
+
+Beware that by this point, the Silverstripe framework features you normally rely on (e.g.: ORM, Injector, services configured by Injector, the config API) won't be
+available in your middleware or in `index.php` because they won't have been initialised yet.
 
 For example, Silverstripe's autoloading functionality won't work in `index.php`. So you might have to take additional
-steps to load your custom middleware class.
+steps to load your custom middleware class if it isn't being autoloaded by [composer's autoloading](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 
-[Configuring autoloading in your `composer.json` file](https://getcomposer.org/doc/04-schema.md#autoload) is the best
-way to achieve this. Remember to call `composer dump-autoload` to regenerate your autoloader. 
+We recommend explicitly [configuring autoloading in your `composer.json` file](https://getcomposer.org/doc/04-schema.md#autoload).
+Remember to call `composer dump-autoload` to regenerate your autoloader.
 
-Alternatively, you can manually include the file containing your custom middleware with a `require` call. e.g.: 
-`require __DIR__.'/../app/src/MyApplicationMiddleware.php';`
+Alternatively, you can manually include the file containing your custom middleware with a `require` call. e.g:
+
+```php
+require __DIR__ . '/../app/src/MyApplicationMiddleware.php';
+```
+
+Note that using `require` in this way won't automatically load any additional classes your middleware relies on.
 
 ## API Documentation
 

--- a/en/02_Developer_Guides/02_Controllers/06_Builtin_Middlewares.md
+++ b/en/02_Developer_Guides/02_Controllers/06_Builtin_Middlewares.md
@@ -5,18 +5,20 @@ summary: Middleware components that come with Silverstripe CMS
 
 # Built-in Middleware
 
-Silverstripe CMS has a number of Middleware components.
-You may find them in the [SilverStripe\Control\Middleware](api:SilverStripe\Control\Middleware) namespace.
+Silverstripe CMS has a number of Middleware components. Some of them are listed here.
+Many of them are in the [SilverStripe\Control\Middleware](api:SilverStripe\Control\Middleware) namespace.
 
 | Name | Description |
 | ---- | ----------- |
 | [AllowedHostsMiddleware](api:SilverStripe\Control\Middleware\AllowedHostsMiddleware) | Secures requests by only allowing a whitelist of Host values |
+| [AuthenticationMiddleware](api:SilverStripe\Security\AuthenticationMiddleware) | Handles authentication for the request |
 | [CanonicalURLMiddleware](api:SilverStripe\Control\Middleware\CanonicalURLMiddleware) | URL normalisation and redirection |
-| [ChangeDetectionMiddleware](api:SilverStripe\Control\Middleware\ChangeDetectionMiddleware) | Change detection via Etag / IfModifiedSince headers, conditionally sending a 304 not modified if possible. |\
+| [ChangeDetectionMiddleware](api:SilverStripe\Control\Middleware\ChangeDetectionMiddleware) | Change detection via Etag / IfModifiedSince headers, conditionally sending a 304 not modified if possible. |
 | [ConfirmationMiddleware](api:SilverStripe\Control\Middleware\ConfirmationMiddleware) | Checks whether user manual confirmation is required for HTTPRequest |
 | [ExecMetricMiddleware](api:SilverStripe\Control\Middleware\ExecMetricMiddleware) | Display execution metrics in DEV mode |
 | [FlushMiddleware](api:SilverStripe\Control\Middleware\FlushMiddleware) | Triggers a call to flush() on all [Flushable](api:SilverStripe\Core\Flushable) implementors |
 | [HTTPCacheControlMiddleware](api:SilverStripe\Control\Middleware\HTTPCacheControlMiddleware) | Controls HTTP response cache headers |
+| [PasswordExpirationMiddleware](api:SilverStripe\Security\PasswordExpirationMiddleware) | Check if authenticated user has password expired |
 | [RateLimitMiddleware](api:SilverStripe\Control\Middleware\RateLimitMiddleware) | Access throttling, controls HTTP Retry-After header |
 | [SessionMiddleware](api:SilverStripe\Control\Middleware\SessionMiddleware) | PHP Session initialisation |
 | [TrustedProxyMiddleware](api:SilverStripe\Control\Middleware\TrustedProxyMiddleware) | Rewrites headers that provide IP and host details from upstream proxies |


### PR DESCRIPTION
A (relatively quick) sweep over the controllers section of the docs to update any false or outdated information.

Note: This should be reviewed _after_ https://github.com/silverstripe/developer-docs/pull/188

## Scope
The primary purpose of this PR is to ensure that:
1. code examples actually work in CMS 5
2. written documentation is factually correct

In many cases I may have also augmented the existing documentation to make it clearer or to add information I felt was missing.

There may also be cases where I have updated code examples or written documentation to better reflect best practices - but that is _not_ the main purpose of this PR. If there are areas where I have not updated examples or docs to reflect best practices (but those examples work and the docs are factually correct) then they are _out of scope_ for this PR.

Formatting that I haven't explicitly touched is definitely out of scope.

## Issue
- https://github.com/silverstripe/developer-docs/issues/164