### PR TITLE
DOC Remove former core committers

### DIFF
--- a/en/06_Project_Governance/01_Core_committers.md
+++ b/en/06_Project_Governance/01_Core_committers.md
@@ -13,8 +13,6 @@ This page outlines those who are part of the Core Committer team and outlines th
 ## Core Committer team
 
 * [Aaron Carlino](https://github.com/unclecheese/)
-* [Chris Joe](https://github.com/flamerohr/)
-* [Daniel Hensby](https://github.com/dhensby)
 * [Garion Herman](https://github.com/cheddam)
 * [Guy Marriott](https://github.com/ScopeyNZ)
 * [Guy Sartorelli](https://github.com/GuySartorelli)


### PR DESCRIPTION
Remove Dan and Chris from list of core committers. Chris hasn't been a core committer in ages. Dan stepped down recently.

## Parent issue
https://github.com/silverstripeltd/product-issues/issues/719