### PR TITLE
DOC Reapply reverted changes to versioning docs

### DIFF
--- a/en/02_Developer_Guides/00_Model/10_Versioning.md
+++ b/en/02_Developer_Guides/00_Model/10_Versioning.md
@@ -988,7 +988,7 @@ module.exports = [
 console.log('Hello world');
 ```
 
-At this stage, running `yarn build` correctly build `app/client/dist/js/bundle.js`.
+At this stage, running `yarn build` should correctly build `app/client/dist/js/bundle.js`.
 
 [notice]
 Don't forget to [configure your project's "exposed" folders](/developer_guides/templates/requirements/#configuring-your-project-exposed-folders) and run `composer vendor-expose` on the command line so that the browser has access to your new dist js file.
@@ -1207,7 +1207,7 @@ mutation revertToMyVersionedObject($id:ID!, $toVersion:Int!) {
 
 const config = {
   props: ({ mutate, ownProps: { actions } }) => {
-    const revertToMyVersionedObject = (id, toVersion) => mutate({
+    const revertToVersion = (id, toVersion) => mutate({
       variables: {
         id,
         toVersion,
@@ -1217,7 +1217,7 @@ const config = {
     return {
       actions: {
         ...actions,
-        revertToMyVersionedObject,
+        revertToVersion,
       },
     };
   },


### PR DESCRIPTION
Reapplies the changes to versioning docs that were [reverted](https://github.com/silverstripe/developer-docs/pull/199)

## NOTE
The revert commit was not completed correctly. It was meant to revert the entirety of https://github.com/silverstripe/developer-docs/pull/184 and https://github.com/silverstripe/developer-docs/pull/197, but failed to do so!
That's okay because this commit would have reinstated those PRs anyway.

Make sure you test and review _the entirety_ of the graphql/javascript code from `## Using the history viewer` to the end of the file. That includes both the graphql 3 _and_ graphql 4 sections! _ALL_ of that is in scope for this PR.

## Issue
- https://github.com/silverstripe/developer-docs/issues/62