### PR TITLE
DOC Clearly document the replacement for $ThemeDir

### DIFF
--- a/en/02_Developer_Guides/01_Templates/03_Requirements.md
+++ b/en/02_Developer_Guides/01_Templates/03_Requirements.md
@@ -441,24 +441,47 @@ Requirements::set_write_js_to_body(false);
 
 ## Direct resource urls
 
-In templates, you can use the `$resourcePath()` or `$resourceURL()` helper methods to inject links to
-resources directly. If you want to link to resources within a specific module you can use 
-the `vendor/module:some/path/to/file.jpg` syntax.
+In templates, you can use the [`$themedResourceURL()`](api:SilverStripe\View\ThemeResourceLoader::themedResourceURL()) or [`$resourceURL()`](api:SilverStripe\Core\Manifest\ModuleResourceLoader::resourceURL()) helper methods to inject links to
+resources directly.
 
-E.g.
+If you want to get a resource using cascading themes, use `$themedResourceURL()`:
 
 ```ss
-<div class="loading">
-    <img src="$resourceURL('silverstripe/admin:client/dist/images/spinner.gif')" />
-</div>
+<img src="$themedResourceURL('images/my-image.jpg')">
+<img src="$themedResourceURL('images')/$Image.jpg">
 ```
 
-In PHP you can directly resolve these urls using the `ModuleResourceLoader` helper.
+If you want to get a resource for a _specific_ theme or from somewhere that is not a theme (your app directory or a module), use `$resourceURL()`:
+
+```ss
+<img src="$resourceURL('app/images/my-image.jpg')">
+<img src="$resourceURL('my/module:images/my-image.jpg')">
+<img src="$resourceURL('themes/simple/images/my-image.jpg')">
+<img src="$resourceURL('themes/simple/images')/$Image.jpg">
+```
+
+[hint]
+Notice the `vendor/module:some/path/to/file.jpg` syntax (used to get a resource from a specific module) is only valid for the `$resourceURL()` helper method. It won't work for `themedResourceURL()`.
+[/hint]
+
+### Resource URLs or filepaths from a PHP context
+
+In PHP you can directly resolve urls and file paths for resources using the [`ModuleResourceLoader`](api:SilverStripe\Core\Manifest\ModuleResourceLoader) and [`ThemeResourceLoader`](api:SilverStripe\View\ThemeResourceLoader) helpers.
 
 ```php
-$file = ModuleResourceLoader::singleton()
-  ->resolveURL('silverstripe/admin:client/dist/images/spinner.gif');
+use SilverStripe\Core\Manifest\ModuleResourceLoader;
+use SilverStripe\View\ThemeResourceLoader;
+
+// Get the URL or relative file path for an image in the silverstripe/admin module
+$fileUrl = ModuleResourceLoader::singleton()->resolveURL('silverstripe/admin:client/dist/images/spinner.gif');
+$filePath = ModuleResourceLoader::singleton()->resolvePath('silverstripe/admin:client/dist/images/spinner.gif');
+
+// Get the URL or relative file path for an image in a theme, using cascading themes
+$themeFileUrl = ThemeResourceLoader::themedResourceURL('images/spinner.gif');
+$themeFilePath = ThemeResourceLoader::inst()->findThemedResource('images/spinner.gif');
 ```
+
+You can also get file paths specifically for javascript and css files using the [`findThemedJavascript()`](api:SilverStripe\Core\Manifest\ModuleResourceLoader::findThemedJavascript()) and [`findThemedCss()`](api:SilverStripe\Core\Manifest\ModuleResourceLoader::findThemedCss()) methods.
 
 ## Related Lessons
 * [Creating your first theme](https://www.silverstripe.org/learn/lessons/v4/creating-your-first-theme-1)

--- a/en/04_Changelogs/5.0.0.md
+++ b/en/04_Changelogs/5.0.0.md
@@ -537,15 +537,39 @@ This is a major release and contains many breaking API changes. Deprecation warn
 
 ### Templates
 
-- `<% loop %>` and `<% with %>` now only ever result in one new scope level. See [Template Syntax](/developer_guides/templates/syntax#up) for more details.
+#### Loop and With scope changes
 
-  For example `<% loop $Pages.Limit(5) %>{$Up.Up.Title}<% end_loop %>` previously would go up once to the `$Pages` scope (out of the `$Pages.limit(5)` scope), then up a second time to the parent scope. Now there is only the parent scope and the `$Pages.limit(5)` scope - there is no implied `$Pages` scope.
+`<% loop %>` and `<% with %>` now only ever result in one new scope level. See [Template Syntax](/developer_guides/templates/syntax#up) for more details.
 
-  You may need to do a search for `$Up.Up` in your templates to resolve situations where you have worked around this - with the example above, you would need to rewrite it to `$Up.Title` (removing the second `Up`).
+For example `<% loop $Pages.Limit(5) %>{$Up.Up.Title}<% end_loop %>` previously would go up once to the `$Pages` scope (out of the `$Pages.limit(5)` scope), then up a second time to the parent scope. Now there is only the parent scope and the `$Pages.limit(5)` scope - there is no implied `$Pages` scope.
 
-- Numeric, boolean and null values passed to methods in templates will now preserve their type, rather than always being cast to strings. E.g. `$Foo(true)` would previously pass a string argument `'true'` to the `Foo()` method, but will now pass an actual boolean.
+You may need to do a search for `$Up.Up` in your templates to resolve situations where you have worked around this - with the example above, you would need to rewrite it to `$Up.Title` (removing the second `Up`).
 
-  You may need to check for situations where you were working around this limitation, such as checking in php code for `$param === 'false'` if you were passing `false` into some method from a template.
+#### Primitive values can be passed into method calls
+
+Numeric, boolean and null values passed to methods in templates will now preserve their type, rather than always being cast to strings. E.g. `$Foo(true)` would previously pass a string argument `'true'` to the `Foo()` method, but will now pass an actual boolean.
+
+You may need to check for situations where you were working around this limitation, such as checking in php code for `$param === 'false'` if you were passing `false` into some method from a template.
+
+#### `$ThemeDir` has been replaced
+
+[`$ThemeDir`](api:SilverStripe\View\ViewableData::ThemeDir()) has been removed. Depending on your use case, you should use one of the following replacements instead:
+
+If you want to get a resource using cascading themes, use [`$themedResourceURL()`](api:SilverStripe\View\ThemeResourceLoader::themedResourceURL()):
+
+```ss
+<img src="$themedResourceURL('images/my-image.jpg')">
+<img src="$themedResourceURL('images')/$Image.jpg">
+```
+
+If you want to get a resource for a _specific_ theme or from somewhere that is not a theme (your app directory or a module), use [`$resourceURL()`](api:SilverStripe\Core\Manifest\ModuleResourceLoader::resourceURL()):
+
+```ss
+<img src="$resourceURL('app/images/my-image.jpg')">
+<img src="$resourceURL('my/module:images/my-image.jpg')">
+<img src="$resourceURL('themes/simple/images/my-image.jpg')">
+<img src="$resourceURL('themes/simple/images')/$Image.jpg">
+```
 
 ### Removed and changed API (by module, alphabetically) {#api-removed-and-changed}
 


### PR DESCRIPTION
1. Document the options for what to replace `$ThemeDir` with
2. Make it clearer that you can use these with directories _as well_ as full file paths
3. Don't recommend `$resourcePath` to be used in templates, as that's for _file paths_ not for URLs.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10747