### PR TITLE
DOC Be more explicit about web vs project roots

### DIFF
--- a/en/02_Developer_Guides/04_Configuration/03_Environment_Variables.md
+++ b/en/02_Developer_Guides/04_Configuration/03_Environment_Variables.md
@@ -7,7 +7,7 @@ icon: dollar-sign
 # Environment Variables
 
 Environment specific variables like database connection details, API keys and other server configuration should be kept 
-outside the application code in a separate `.env` file. This file is stored in the web root and 
+outside the application code in a separate `.env` file. This file is stored outside of the web root (i.e. not in the `/public/` folder) and 
 kept out of version control for security reasons.
 
 For more information see our docs on [Environment Management](../../getting_started/environment_management/).

--- a/en/02_Developer_Guides/05_Extending/00_Modules.md
+++ b/en/02_Developer_Guides/05_Extending/00_Modules.md
@@ -35,7 +35,7 @@ with [Composer](../../getting_started/composer).
 
 Each module has a unique identifier, consisting of a vendor prefix and name. For example, the "blog" module has the
 identifier `silverstripe/blog` as it is published by *silverstripe*. To install, use the following command executed in
-the root folder:
+the project root folder:
 
 ```bash
 composer require silverstripe/blog *@stable

--- a/en/02_Developer_Guides/06_Testing/How_Tos/00_Write_a_SapphireTest.md
+++ b/en/02_Developer_Guides/06_Testing/How_Tos/00_Write_a_SapphireTest.md
@@ -87,7 +87,7 @@ database and discarded at the end of the test.
 
 [notice]
 The `fixture_file` property can be path to a file, or an array of strings pointing to many files. The path must be 
-absolute from your website's root folder.
+absolute from your project root folder.
 [/notice]
 
 The second part of our class is the `testURLGeneration` method. This method is our test. When the test is executed, 

--- a/en/02_Developer_Guides/09_Security/03_Authentication.md
+++ b/en/02_Developer_Guides/09_Security/03_Authentication.md
@@ -52,7 +52,7 @@ When a new Silverstripe CMS site is created for the first time, it may be necess
 CMS access for the first time. Silverstripe CMS provides a default admin configuration system, which allows a username
 and password to be configured for a single special user outside of the normal membership system.
 
-It is advisable to configure this user in your `.env` file inside of the web root, as below:
+It is advisable to configure this user in your `.env` file inside of the project root, as below:
 
 ```
 # Configure a default username and password to access the CMS on all sites in this environment.

--- a/en/02_Developer_Guides/09_Security/05_Secure_Coding.md
+++ b/en/02_Developer_Guides/09_Security/05_Secure_Coding.md
@@ -501,7 +501,7 @@ for instructions on how to secure the assets folder against malicious script exe
 
 ### Don't run Silverstripe in the webroot
 
-Silverstripe routes all execution through a [`public/` subfolder](/getting_started/directory_structure))
+Silverstripe routes all execution through a [`public/` subfolder](/getting_started/directory_structure)
 by default. This enables you to keep application code and configuration outside of webserver routing.
 
 ```

--- a/en/02_Developer_Guides/16_Execution_Pipeline/02_Manifests.md
+++ b/en/02_Developer_Guides/16_Execution_Pipeline/02_Manifests.md
@@ -27,7 +27,7 @@ interface provided by [php-fig/cache](https://github.com/php-fig/cache).
 
 ## Traversing the Filesystem
 
-Since manifests usually extract their information from files in the webroot,
+Since manifests usually extract their information from files in the project root,
 they require a powerful traversal tool: [FileFinder](api:SilverStripe\Assets\FileFinder).
 The class provides filtering abilities for files and folders, as well as
 callbacks for recursive traversal. Each manifest has its own implementation,
@@ -55,9 +55,13 @@ as well as [ClassInfo](api:SilverStripe\Core\ClassInfo). Some useful commands of
 
 In the absence of a generic module API, it is also the primary way to identify
 which modules are installed, through [ClassManifest::getModules()](api:SilverStripe\Core\Manifest\ClassManifest::getModules()).
-A module is defined as a toplevel folder in the webroot which contains
-either a `_config.php` file, or a `_config/` folder. Modules can be specifically
+All modules contain either a `_config.php` file, or a `_config/` folder. Modules can be specifically
 excluded from manifests by creating a blank `_manifest_exclude` file in the module folder.
+
+Modules can either be:
+
+* a toplevel folder in the project root, or
+* a third-party package installed via composer (i.e. in the `vendor/` directory).
 
 By default, the finder implementation will exclude any classes stored in files within
 a `tests/` folder, unless tests are executed.

--- a/en/02_Developer_Guides/16_Execution_Pipeline/03_App_Object_and_Kernel.md
+++ b/en/02_Developer_Guides/16_Execution_Pipeline/03_App_Object_and_Kernel.md
@@ -70,9 +70,8 @@ The role of the application is to:
 The HTTPApplication provides a specialised application implementation for handling HTTP Requests.
 This class provides basic support for HTTP Middleware, such as [ErrorControlChainMiddleware](api:SilverStripe\Core\Startup\ErrorControlChainMiddleware).
 
-The `index.php` file in your project root contains the default application implementation.
+The `index.php` file in your web root contains the default application implementation.
 You can customise it as required.
-
 
 ```php
 

--- a/en/02_Developer_Guides/16_Execution_Pipeline/index.md
+++ b/en/02_Developer_Guides/16_Execution_Pipeline/index.md
@@ -31,7 +31,7 @@ This is included automatically when the composer `vendor/autoload.php` is includ
 tasks silently in the background.
 
   * Tries to locate an `.env` 
-   [configuration file](/getting_started/environment_management) in the webroot.
+   [configuration file](/getting_started/environment_management) in the project root.
   * Sets constants based on the filesystem structure (e.g. `BASE_URL`, `BASE_PATH` and `TEMP_PATH`)
 
 All requests go through `index.php`, which sets up the core [Kernel](api:SilverStripe\Core\Kernel) and [HTTPApplication](api:SilverStripe\Control\HTTPApplication)

--- a/en/02_Developer_Guides/17_CLI/index.md
+++ b/en/02_Developer_Guides/17_CLI/index.md
@@ -13,7 +13,7 @@ The main entry point for any command line execution is `cli-script.php` in the f
 For example, to run a database rebuild from the command line, use this command:
 
 ```bash
-cd your-webroot/
+cd your-project-root/
 php vendor/silverstripe/framework/cli-script.php dev/build
 ```
 
@@ -38,7 +38,7 @@ when running the command php -v, then you may not have php-cli installed so sake
 `sake` can be invoked using `./vendor/bin/sake`. For easier access, copy the `sake` file into `/usr/bin/sake`.
 
 ```
-cd your-webroot/
+cd your-project-root/
 sudo ./vendor/bin/sake installsake
 ```
 
@@ -136,7 +136,7 @@ sake -stop MyProcess
 ```
 
 [notice]
-`sake` stores `pid` and log files in the site root directory.
+`sake` stores `pid` and log files in the project root directory.
 [/notice]
 
 ## Arguments
@@ -144,7 +144,7 @@ sake -stop MyProcess
 Parameters can be added to the command. All parameters will be available in `$_GET` array on the server.
 
 ```bash
-cd your-webroot/
+cd your-project-root/
 php vendor/silverstripe/framework/cli-script.php myurl myparam=1 myotherparam=2
 ```
 


### PR DESCRIPTION
Any time a root directory is mentioned, we need to be explicit as to whether it's the _project_ root (i.e. where the `composer.json` file is) or the _web_ root (i.e. inside the `public/` directory).

## Issues
- https://github.com/silverstripe/silverstripe-framework/issues/8168