### PR TITLE
DOCS: Add note regarding the split of the activedirectory module

### DIFF
--- a/en/04_Changelogs/5.0.0.md
+++ b/en/04_Changelogs/5.0.0.md
@@ -172,7 +172,7 @@ Module | Status | Notes
 [hafriedlander/phockito](https://packagist.org/packages/hafriedlander/phockito) | Dropped | 
 [hafriedlander/silverstripe-phockito](https://packagist.org/packages/hafriedlander/silverstripe-phockito) | Dropped | 
 [lekoala/silverstripe-debugbar](https://packagist.org/packages/lekoala/silverstripe-debugbar) | CMS5 compatible without commercial support | Debug bar is a development tool that should not be installed in production.
-[silverstripe/activedirectory](https://packagist.org/packages/silverstripe/activedirectory) | Dropped | 
+[silverstripe/activedirectory](https://packagist.org/packages/silverstripe/activedirectory) | Dropped | This module was split into two separate modules. Use the [silverstripe/saml](https://github.com/silverstripe/silverstripe-saml) and/or [silverstripe/ldap](https://github.com/silverstripe/silverstripe-ldap) modules depending on your needs. Note that the `silverstripe/saml` module is not commercially supported. |
 [silverstripe/akismet](https://packagist.org/packages/silverstripe/akismet) | Dropped | The parent library is outdated and there are better alternatives like [UndefinedOffset/silverstripe-nocaptcha](https://packagist.org/packages/undefinedoffset/silverstripe-nocaptcha)
 [silverstripe/behat-extension](https://packagist.org/packages/silverstripe/behat-extension) | CMS5 compatible without commercial support | 
 [silverstripe/ckan-registry](https://packagist.org/packages/silverstripe/ckan-registry) | CMS5 compatible without commercial support | 


### PR DESCRIPTION
Has been split into the saml and ldap modules. Also note that the saml module is not commercially supported.