### PR TITLE
DOC Remove links for unsupported modules

### DIFF
--- a/en/04_Changelogs/5.0.0.md
+++ b/en/04_Changelogs/5.0.0.md
@@ -589,7 +589,7 @@ This is a major release and contains many breaking API changes. Deprecation warn
 - `isDev` and `isTest` query string arguments have been removed due to security concerns (see [ss-2018-005](https://www.silverstripe.org/download/security-releases/ss-2018-005/)).
 - The `updateRelativeLink()` extension hook for updating the result of [SiteTree::RelativeLink()](api:SilverStripe\CMS\Model\SiteTree::RelativeLink()) has changed signature, allowing you to update the resultant link itself instead of just the component parts. If you are using this extension hook, you will need to update the method signature and logic to match. See [SiteTreeExtension::updateRelativeLink()](api:SilverStripe\CMS\Model\SiteTreeExtension::updateRelativeLink()) for more details.
 - The default value for the `RESOURCES_DIR` const has been changed to "_resources"
-  - The [`Library::DEFAULT_RESOURCES_DIR`](api:SilverStripe\VendorPlugin\Library::DEFAULT_RESOURCES_DIR) constant in `silverstripe/vendor-plugin` has been changed to match.
+  - The `Library::DEFAULT_RESOURCES_DIR` constant in `silverstripe/vendor-plugin` has been changed to match.
   - This can still be customised using `extra.resources-dir` in your `composer.json` file (see the [configuring your project exposed folders](/developer_guides/templates/requirements/#configuring-your-project-exposed-folders) documentation).
   - If your `composer.json` file has its `extra.resources-dir` key set to `_resources`, you can remove that now.
   - If your `composer.json` file already does not have an `extra.resources-dir` key and you want to keep your resources in the `resources` directory, you can set `extra.resources-dir` to `resources`.
@@ -696,7 +696,7 @@ This sections contains the full list of APIs that have been changed or removed b
 
 ### cwp/cwp-search
 
-- Removed deprecated class `CWP\Search\Solr\CwpSolrConfigStore` - use [`SilverStripe\FullTextSearch\Solr\Stores\SolrConfigStore_Post`](api:SilverStripe\FullTextSearch\Solr\Stores\SolrConfigStore_Post) in `silverstripe/fulltextsearch` instead
+- Removed deprecated class `CWP\Search\Solr\CwpSolrConfigStore` - use `SilverStripe\FullTextSearch\Solr\Stores\SolrConfigStore_Post` in `silverstripe/fulltextsearch` instead
 
 ### dnadesign/silverstripe-elemental
 
@@ -723,7 +723,7 @@ This sections contains the full list of APIs that have been changed or removed b
 - Class [`SilverStripe\Admin\SecurityAdmin`](api:SilverStripe\Admin\SecurityAdmin) now extends [`SilverStripe\Admin\ModelAdmin`](api:SilverStripe\Admin\ModelAdmin) instead of [`SilverStripe\Admin\LeftAndMain`](api:SilverStripe\Admin\LeftAndMain)
 - Removed deprecated class `SilverStripe\Admin\GroupImportForm` without equivalent functionality to replace it
 - Removed deprecated class `SilverStripe\Admin\MemberImportForm` without equivalent functionality to replace it
-- Removed deprecated method `SilverStripe\Admin\LeftAndMain::menu_title_for_class()` - use [`SilverStripe\Admin\LeftAndMain::menu_title()`](SilverStripe\Admin\LeftAndMain::menu_title()) instead
+- Removed deprecated method `SilverStripe\Admin\LeftAndMain::menu_title_for_class()` - use [`SilverStripe\Admin\LeftAndMain::menu_title()`](api:SilverStripe\Admin\LeftAndMain::menu_title()) instead
 - Removed deprecated method `SilverStripe\Admin\ModelAdmin::getSearchContext()` - use [`SilverStripe\Forms\GridField\GridFieldFilterHeader`](api:SilverStripe\Forms\GridField\GridFieldFilterHeader) instead
 - Removed deprecated method `SilverStripe\Admin\ModelAdmin::SearchForm()` - use [`SilverStripe\Forms\GridField\GridFieldFilterHeader`](api:SilverStripe\Forms\GridField\GridFieldFilterHeader) instead
 - Removed deprecated method `SilverStripe\Admin\ModelAdmin::SearchSummary()` - use [`SilverStripe\Forms\GridField\GridFieldFilterHeader`](api:SilverStripe\Forms\GridField\GridFieldFilterHeader) instead
@@ -735,7 +735,7 @@ This sections contains the full list of APIs that have been changed or removed b
 - Removed deprecated method `SilverStripe\Admin\SecurityAdmin::MemberImportForm()` without equivalent functionality to replace it
 - Removed deprecated method `SilverStripe\Admin\SecurityAdmin::roles()` without equivalent functionality to replace it
 - Removed deprecated method `SilverStripe\Admin\SecurityAdmin::users()` without equivalent functionality to replace it
-- Removed deprecated config `SilverStripe\Admin\LeftAndMain.help_link` - use [`SilverStripe\Admin\LeftAndMain.help_links`](api:SilverStripe\Admin\LeftAndMain.help_links) instead
+- Removed deprecated config `SilverStripe\Admin\LeftAndMain.help_link` - use `SilverStripe\Admin\LeftAndMain.help_links` instead
 - Removed deprecated config `SilverStripe\Admin\SecurityAdmin.subitem_class` without equivalent functionality to replace it
 - Removed deprecated parameter in [`SilverStripe\Admin\ModelAdmin::import()`](api:SilverStripe\Admin\ModelAdmin::import()) named `$request`
 - Changed return type for [`SilverStripe\Admin\AdminRootController::handleRequest()`](api:SilverStripe\Admin\AdminRootController::handleRequest()) from dynamic to [`SilverStripe\Control\HTTPResponse`](api:SilverStripe\Control\HTTPResponse)
@@ -827,7 +827,7 @@ This sections contains the full list of APIs that have been changed or removed b
 - Removed deprecated method `SilverStripe\Assets\Flysystem\FlysystemAssetStore::cleanFilename()` - use [`SilverStripe\Assets\FilenameParsing\FileIDHelper::cleanFilename()`](api:SilverStripe\Assets\FilenameParsing\FileIDHelper::cleanFilename()) instead
 - Removed deprecated method `SilverStripe\Assets\Flysystem\FlysystemAssetStore::deleteFromFilesystem()` - use [`SilverStripe\Assets\Flysystem\FlysystemAssetStore::deleteFromFileStore()`](api:SilverStripe\Assets\Flysystem\FlysystemAssetStore::deleteFromFileStore()) instead
 - Removed deprecated method `SilverStripe\Assets\Flysystem\FlysystemAssetStore::findVariants()` - use [`SilverStripe\Assets\FilenameParsing\FileResolutionStrategy::findVariants()`](api:SilverStripe\Assets\FilenameParsing\FileResolutionStrategy::findVariants()) instead
-- Removed deprecated method `SilverStripe\Assets\Flysystem\FlysystemAssetStore::getFilesystemFor()` - use [`SilverStripe\Assets\Flysystem\FlysystemAssetStore::applyToFileIDOnFilesystem()`](SilverStripe\Assets\Flysystem\FlysystemAssetStore::applyToFileIDOnFilesystem()) instead
+- Removed deprecated method `SilverStripe\Assets\Flysystem\FlysystemAssetStore::getFilesystemFor()` - use `SilverStripe\Assets\Flysystem\FlysystemAssetStore::applyToFileIDOnFilesystem()` instead
 - Removed deprecated method `SilverStripe\Assets\Flysystem\FlysystemAssetStore::getOriginalFilename()` - use [`SilverStripe\Assets\FilenameParsing\FileResolutionStrategy::parseFileID()`](api:SilverStripe\Assets\FilenameParsing\FileResolutionStrategy::parseFileID()) and [`SilverStripe\Assets\FilenameParsing\ParsedFileID::getFilename()`](api:SilverStripe\Assets\FilenameParsing\ParsedFileID::getFilename()) instead
 - Removed deprecated method `SilverStripe\Assets\Flysystem\FlysystemAssetStore::getStreamSHA1()` - use [`SilverStripe\Assets\Storage\FileHashingService::computeFromStream()`](api:SilverStripe\Assets\Storage\FileHashingService::computeFromStream()) instead
 - Removed deprecated method `SilverStripe\Assets\Flysystem\FlysystemAssetStore::getVariant()` - use [`SilverStripe\Assets\FilenameParsing\FileResolutionStrategy::parseFileID()`](api:SilverStripe\Assets\FilenameParsing\FileResolutionStrategy::parseFileID()) and [`SilverStripe\Assets\FilenameParsing\ParsedFileID::getVariant()`](api:SilverStripe\Assets\FilenameParsing\ParsedFileID::getVariant()) instead
@@ -864,15 +864,15 @@ This sections contains the full list of APIs that have been changed or removed b
 
 ### silverstripe/behat-extension
 
-- Removed deprecated method `SilverStripe\BehatExtension\Context\BasicContext::iAttachTheFileTo()` - use [`SilverStripe\BehatExtension\Context\BasicContext::iAttachTheFileToTheField()`](api:SilverStripe\BehatExtension\Context\BasicContext::iAttachTheFileToTheField()) instead
-- Changed return type for [`SilverStripe\BehatExtension\Utility\TestMailer::clearEmails()`](api:SilverStripe\BehatExtension\Utility\TestMailer::clearEmails()) from dynamic to `void`
-- Changed return type for [`SilverStripe\BehatExtension\Utility\TestMailer::findEmail()`](api:SilverStripe\BehatExtension\Utility\TestMailer::findEmail()) from dynamic to `array|null`
-- Changed parameter type in [`SilverStripe\BehatExtension\Utility\TestMailer::findEmail()`](api:SilverStripe\BehatExtension\Utility\TestMailer::findEmail()) for `$to` from dynamic to `string`
-- Changed parameter type in [`SilverStripe\BehatExtension\Utility\TestMailer::findEmail()`](api:SilverStripe\BehatExtension\Utility\TestMailer::findEmail()) for `$from` from dynamic to `string|null`
-- Changed parameter type in [`SilverStripe\BehatExtension\Utility\TestMailer::findEmail()`](api:SilverStripe\BehatExtension\Utility\TestMailer::findEmail()) for `$subject` from dynamic to `string|null`
-- Changed parameter type in [`SilverStripe\BehatExtension\Utility\TestMailer::findEmail()`](api:SilverStripe\BehatExtension\Utility\TestMailer::findEmail()) for `$content` from dynamic to `string|null`
-- Changed parameter type in [`SilverStripe\BehatExtension\Utility\TestMailer::saveEmail()`](api:SilverStripe\BehatExtension\Utility\TestMailer::saveEmail()) for `$data` from dynamic to `array`
-- Changed parameter name in [`SilverStripe\BehatExtension\Context\BasicContext::iAddToTheTagField()`](api:SilverStripe\BehatExtension\Context\BasicContext::iAddToTheTagField()) from `$locator` to `$selector`
+- Removed deprecated method `SilverStripe\BehatExtension\Context\BasicContext::iAttachTheFileTo()` - use `SilverStripe\BehatExtension\Context\BasicContext::iAttachTheFileToTheField()` instead
+- Changed return type for `SilverStripe\BehatExtension\Utility\TestMailer::clearEmails()` from dynamic to `void`
+- Changed return type for `SilverStripe\BehatExtension\Utility\TestMailer::findEmail()` from dynamic to `array|null`
+- Changed parameter type in `SilverStripe\BehatExtension\Utility\TestMailer::findEmail()` for `$to` from dynamic to `string`
+- Changed parameter type in `SilverStripe\BehatExtension\Utility\TestMailer::findEmail()` for `$from` from dynamic to `string|null`
+- Changed parameter type in `SilverStripe\BehatExtension\Utility\TestMailer::findEmail()` for `$subject` from dynamic to `string|null`
+- Changed parameter type in `SilverStripe\BehatExtension\Utility\TestMailer::findEmail()` for `$content` from dynamic to `string|null`
+- Changed parameter type in `SilverStripe\BehatExtension\Utility\TestMailer::saveEmail()` for `$data` from dynamic to `array`
+- Changed parameter name in `SilverStripe\BehatExtension\Context\BasicContext::iAddToTheTagField()` from `$locator` to `$selector`
 
 ### silverstripe/campaign-admin
 
@@ -964,14 +964,14 @@ This sections contains the full list of APIs that have been changed or removed b
 
 ### silverstripe/comments
 
-- Removed deprecated class `SilverStripe\Comments\Admin\CommentsGridFieldAction` - use [`SilverStripe\Comments\Admin\CommentsGridFieldApproveAction`](api:SilverStripe\Comments\Admin\CommentsGridFieldApproveAction) or [`SilverStripe\Comments\Admin\CommentsGridFieldSpamAction`](api:SilverStripe\Comments\Admin\CommentsGridFieldSpamAction) instead
-- Removed deprecated class `SilverStripe\Comments\Admin\CommentsGridFieldBulkAction\Handler` - use [`SilverStripe\Comments\Admin\CommentsGridFieldBulkAction\SpamHandler`](api:SilverStripe\Comments\Admin\CommentsGridFieldBulkAction\SpamHandler) or [`SilverStripe\Comments\Admin\CommentsGridFieldBulkAction\ApproveHandler`](api:SilverStripe\Comments\Admin\CommentsGridFieldBulkAction\ApproveHandler) instead
-- Removed deprecated method `SilverStripe\Comments\Model\Comment::getParent()` - use [`SilverStripe\Comments\Model\Comment::Parent()`](api:SilverStripe\Comments\Model\Comment::Parent()) instead
-- Changed return type for [`SilverStripe\Comments\Controllers\CommentingController::redirectBack()`](api:SilverStripe\Comments\Controllers\CommentingController::redirectBack()) from dynamic to [`SilverStripe\Control\HTTPResponse`](api:SilverStripe\Control\HTTPResponse)
+- Removed deprecated class `SilverStripe\Comments\Admin\CommentsGridFieldAction` - use `SilverStripe\Comments\Admin\CommentsGridFieldApproveAction` or `SilverStripe\Comments\Admin\CommentsGridFieldSpamAction` instead
+- Removed deprecated class `SilverStripe\Comments\Admin\CommentsGridFieldBulkAction\Handler` - use `SilverStripe\Comments\Admin\CommentsGridFieldBulkAction\SpamHandler` or `SilverStripe\Comments\Admin\CommentsGridFieldBulkAction\ApproveHandler` instead
+- Removed deprecated method `SilverStripe\Comments\Model\Comment::getParent()` - use `SilverStripe\Comments\Model\Comment::Parent()` instead
+- Changed return type for `SilverStripe\Comments\Controllers\CommentingController::redirectBack()` from dynamic to [`SilverStripe\Control\HTTPResponse`](api:SilverStripe\Control\HTTPResponse)
 
 ### silverstripe/config
 
-- Removed deprecated method `SilverStripe\Config\Collections\DeltaConfigCollection::unserialize()` - use [`SilverStripe\Config\Collections\DeltaConfigCollection::__unserialize()`](SilverStripe\Config\Collections\DeltaConfigCollection::__unserialize()) instead
+- Removed deprecated method `SilverStripe\Config\Collections\DeltaConfigCollection::unserialize()` - use [`SilverStripe\Config\Collections\DeltaConfigCollection::__unserialize()`](api:SilverStripe\Config\Collections\DeltaConfigCollection::__unserialize()) instead
 - Removed deprecated method `SilverStripe\Config\Collections\MemoryConfigCollection::serialize()` - use [`SilverStripe\Config\Collections\MemoryConfigCollection::__serialize()`](api:SilverStripe\Config\Collections\MemoryConfigCollection::__serialize()) instead
 - Removed deprecated method `SilverStripe\Config\Collections\MemoryConfigCollection::unserialize()` - use [`SilverStripe\Config\Collections\MemoryConfigCollection::__unserialize()`](api:SilverStripe\Config\Collections\MemoryConfigCollection::__unserialize()) instead
 - Removed deprecated method `SilverStripe\Config\Collections\MemoryConfigCollection::update()` - use [`SilverStripe\Config\Collections\MemoryConfigCollection::merge()`](api:SilverStripe\Config\Collections\MemoryConfigCollection::merge()) instead
@@ -1017,7 +1017,7 @@ This sections contains the full list of APIs that have been changed or removed b
 ### silverstripe/crontask
 
 - Removed deprecated method `SilverStripe\CronTask\Controllers\CronTaskController::setQuiet()` - use [`SilverStripe\CronTask\Controllers\CronTaskController::setVerbosity()`](api:SilverStripe\CronTask\Controllers\CronTaskController::setVerbosity()) instead
-- Removed deprecated property `SilverStripe\CronTask\Controllers\CronTaskController::$quiet` - use [`SilverStripe\CronTask\Controllers\CronTaskController.verbosity`](api:SilverStripe\CronTask\Controllers\CronTaskController.verbosity) instead
+- Removed deprecated property `SilverStripe\CronTask\Controllers\CronTaskController::$quiet` - use `SilverStripe\CronTask\Controllers\CronTaskController.verbosity` instead
 
 ### silverstripe/environmentcheck
 
@@ -1099,7 +1099,7 @@ This sections contains the full list of APIs that have been changed or removed b
 - Removed deprecated method `SilverStripe\Core\Convert::raw2json()` - use [`json_encode()`](https://www.php.net/manual/en/function.json-encode.php) instead
 - Removed deprecated method `SilverStripe\Core\Convert::recursiveXMLToArray()` without equivalent functionality to replace it
 - Removed deprecated method `SilverStripe\Core\Convert::xml2array()` - use a dedicated XML library instead
-- Removed deprecated method `SilverStripe\Core\CustomMethods::findMethodsFromExtension()` - use [`SilverStripe\Core\CustomMethods::findMethodsFrom()`](api::SilverStripe\Core\CustomMethods::findMethodsFrom()) instead
+- Removed deprecated method `SilverStripe\Core\CustomMethods::findMethodsFromExtension()` - use `SilverStripe\Core\CustomMethods::findMethodsFrom()` instead
 - Removed deprecated method `SilverStripe\Core\Extensible::constructExtensions()` - extensions and methods are now lazy-loaded
 - Removed deprecated method `SilverStripe\Core\Injector\Injector::hasService()` - use [`SilverStripe\Core\Injector\Injector::has()`](api:SilverStripe\Core\Injector\Injector::has()) instead
 - Removed deprecated method `SilverStripe\Core\Manifest\ClassLoader::classExists()` - use [`SilverStripe\Core\ClassInfo::exists()`](api:SilverStripe\Core\ClassInfo::exists()) instead
@@ -1118,8 +1118,8 @@ This sections contains the full list of APIs that have been changed or removed b
 - Removed deprecated method `SilverStripe\Dev\DebugView::writeHeader()` - use [`SilverStripe\Dev\DebugView::renderHeader()`](api:SilverStripe\Dev\DebugView::renderHeader()) instead
 - Removed deprecated method `SilverStripe\Dev\DebugView::writeInfo()` - use [`SilverStripe\Dev\DebugView::renderInfo()`](api:SilverStripe\Dev\DebugView::renderInfo()) instead
 - Removed deprecated method `SilverStripe\Dev\DebugView::writeSourceFragment()` - use [`SilverStripe\Dev\DebugView::renderSourceFragment()`](api:SilverStripe\Dev\DebugView::renderSourceFragment()) instead
-- Removed deprecated method `SilverStripe\Dev\DebugView::writeTrace()` - use [`SilverStripe\Dev\DebugView::renderTrace()`](SilverStripe\Dev\DebugView::renderTrace()) instead
-- Removed deprecated method `SilverStripe\Dev\DebugView::writeVariable()` - use [`SilverStripe\Dev\DebugView::renderVariable()`](SilverStripe\Dev\DebugView::renderVariable()) instead
+- Removed deprecated method `SilverStripe\Dev\DebugView::writeTrace()` - use [`SilverStripe\Dev\DebugView::renderTrace()`](api:SilverStripe\Dev\DebugView::renderTrace()) instead
+- Removed deprecated method `SilverStripe\Dev\DebugView::writeVariable()` - use [`SilverStripe\Dev\DebugView::renderVariable()`](api:SilverStripe\Dev\DebugView::renderVariable()) instead
 - Removed deprecated method `SilverStripe\Dev\Deprecation::dump_settings()` without equivalent functionality to replace it
 - Removed deprecated method `SilverStripe\Dev\Deprecation::get_calling_module_from_trace()` without equivalent functionality to replace it
 - Removed deprecated method `SilverStripe\Dev\Deprecation::get_enabled()` without equivalent functionality to replace it
@@ -1178,7 +1178,7 @@ This sections contains the full list of APIs that have been changed or removed b
 - Removed deprecated method `SilverStripe\Security\Member::logged_in_session_exists()` - use [`SilverStripe\Security\Security::getCurrentUser()`](api:SilverStripe\Security\Security::getCurrentUser()) instead
 - Removed deprecated method `SilverStripe\Security\Member::logIn()` - use [`SilverStripe\Security\Security::setCurrentUser()`](api:SilverStripe\Security\Security::setCurrentUser()) or [`SilverStripe\Security\IdentityStore::logIn()`](api:SilverStripe\Security\IdentityStore::logIn()) instead
 - Removed deprecated method `SilverStripe\Security\Member::logOut()` - use [`SilverStripe\Security\Security::setCurrentUser(null)`](api:SilverStripe\Security\Security::setCurrentUser()) or an [`SilverStripe\Security\IdentityStore::logOut()`](api:SilverStripe\Security\IdentityStore::logOut()) instead
-- Removed deprecated method `SilverStripe\Security\Member::set_title_columns()` - use [`SilverStripe\Security\Member.title_format`](api:SilverStripe\Security\Member.title_format) config instead
+- Removed deprecated method `SilverStripe\Security\Member::set_title_columns()` - use `SilverStripe\Security\Member.title_format` config instead
 - Removed deprecated method `SilverStripe\Security\PasswordValidator::characterStrength()` - use [`SilverStripe\Security\PasswordValidator::setMinTestScore()`](api:SilverStripe\Security\PasswordValidator::setMinTestScore()) and [`SilverStripe\Security\PasswordValidator::setTestNames()`](api:SilverStripe\Security\PasswordValidator::setTestNames()) instead
 - Removed deprecated method `SilverStripe\Security\PasswordValidator::checkHistoricalPasswords()` - use [`SilverStripe\Security\PasswordValidator::setHistoricCount()`](api:SilverStripe\Security\PasswordValidator::setHistoricCount()) instead
 - Removed deprecated method `SilverStripe\Security\PasswordValidator::minLength()` - use [`SilverStripe\Security\PasswordValidator::setMinLength()`](api:SilverStripe\Security\PasswordValidator::setMinLength()) instead
@@ -1189,7 +1189,7 @@ This sections contains the full list of APIs that have been changed or removed b
 - Removed deprecated method `SilverStripe\Security\Security::check_default_admin()` - use [`SilverStripe\Security\DefaultAdminService::isDefaultAdminCredentials()`](api:SilverStripe\Security\DefaultAdminService::isDefaultAdminCredentials()) instead
 - Removed deprecated method `SilverStripe\Security\Security::clear_default_admin()` - use [`SilverStripe\Security\DefaultAdminService::clearDefaultAdmin()`](api:SilverStripe\Security\DefaultAdminService::clearDefaultAdmin()) instead
 - Removed deprecated method `SilverStripe\Security\Security::default_admin_password()` - use [`SilverStripe\Security\DefaultAdminService::getDefaultAdminPassword()`](api:SilverStripe\Security\DefaultAdminService::getDefaultAdminPassword()) instead
-- Removed deprecated method `SilverStripe\Security\Security::default_admin_username()` - use [`SilverStripe\Security\DefaultAdminService::getDefaultAdminUsername()`](SilverStripe\Security\DefaultAdminService::getDefaultAdminUsername()) instead
+- Removed deprecated method `SilverStripe\Security\Security::default_admin_username()` - use [`SilverStripe\Security\DefaultAdminService::getDefaultAdminUsername()`](api:SilverStripe\Security\DefaultAdminService::getDefaultAdminUsername()) instead
 - Removed deprecated method `SilverStripe\Security\Security::findAnAdministrator()` - use [`SilverStripe\Security\DefaultAdminService::findOrCreateDefaultAdmin()`](api:SilverStripe\Security\DefaultAdminService::findOrCreateDefaultAdmin()) instead
 - Removed deprecated method `SilverStripe\Security\Security::getLoginForms()` - use `delegateToMultipleHandlers()` instead
 - Removed deprecated method `SilverStripe\Security\Security::has_default_admin()` - use [`SilverStripe\Security\DefaultAdminService::hasDefaultAdmin()`](api:SilverStripe\Security\DefaultAdminService::hasDefaultAdmin()) instead
@@ -1206,10 +1206,10 @@ This sections contains the full list of APIs that have been changed or removed b
 - Removed deprecated config `SilverStripe\Control\Director.alternate_public_dir` without equivalent functionality to replace it
 - Removed deprecated config `SilverStripe\Control\HTTP.cache_ajax_requests`
 - Removed deprecated config `SilverStripe\Control\HTTP.cache_control` - use [`SilverStripe\Control\Middleware\HTTPCacheControlMiddleware`](api:SilverStripe\Control\Middleware\HTTPCacheControlMiddleware) instead
-- Removed deprecated config `SilverStripe\Control\HTTP.disable_http_cache` - use [`SilverStripe\Control\Middleware\HTTPCacheControlMiddleware.defaultState`](api:`SilverStripe\Control\Middleware\HTTPCacheControlMiddleware.defaultState`) or [`SilverStripe\Control\Middleware\HTTPCacheControlMiddleware.defaultForcingLevel`](api:`SilverStripe\Control\Middleware\HTTPCacheControlMiddleware.defaultForcingLevel`)  instead
+- Removed deprecated config `SilverStripe\Control\HTTP.disable_http_cache` - use `SilverStripe\Control\Middleware\HTTPCacheControlMiddleware.defaultState` or `SilverStripe\Control\Middleware\HTTPCacheControlMiddleware.defaultForcingLevel` instead
 - Removed deprecated config `SilverStripe\Control\HTTP.vary` - use [`SilverStripe\Control\Middleware\HTTPCacheControlMiddleware`](api:SilverStripe\Control\Middleware\HTTPCacheControlMiddleware) instead
 - Removed deprecated config `SilverStripe\Forms\GridField\GridFieldFilterHeader.force_legacy` without equivalent functionality to replace it
-- Removed deprecated config `SilverStripe\i18n\Data\Sources.module_priority` - use [`SilverStripe\Core\Manifest\ModuleManifest.module_priority`](api:SilverStripe\Core\Manifest\ModuleManifest.module_priority) instead
+- Removed deprecated config `SilverStripe\i18n\Data\Sources.module_priority` - use `SilverStripe\Core\Manifest\ModuleManifest.module_priority` instead
 - Removed deprecated config `SilverStripe\Security\Permission.declared_permissions` without equivalent functionality to replace it
 - Removed deprecated config `SilverStripe\Security\Permission.declared_permissions_list` without equivalent functionality to replace it
 - Removed deprecated config `SilverStripe\Security\Security.word_list` without equivalent functionality to replace it
@@ -1220,11 +1220,11 @@ This sections contains the full list of APIs that have been changed or removed b
 - Removed deprecated constant `SilverStripe\Core\Manifest\Module::CI_PHPUNIT_NINE` without equivalent functionality to replace it
 - Removed deprecated constant `SilverStripe\Core\Manifest\Module::CI_UNKNOWN` without equivalent functionality to replace it
 - Removed deprecated constant `SilverStripe\Core\Manifest\Module::TRIM_CHARS` - use [`SilverStripe\Core\Path::normalise()`](api:SilverStripe\Core\Path::normalise()) instead
-- Removed deprecated property `SilverStripe\Control\Controller::$basicAuthEnabled` - add this controller's url to [`SilverStripe\Security\BasicAuthMiddleware.URLPatterns`](api:SilverStripe\Security\BasicAuthMiddleware.URLPatterns) injected property instead of setting false
-- Removed deprecated property `SilverStripe\Control\HTTP::$cache_age` - use [`SilverStripe\Control\Middleware\HTTPCacheControlMiddleware::setMaxAge()`](SilverStripe\Control\Middleware\HTTPCacheControlMiddleware::setMaxAge()) instead
+- Removed deprecated property `SilverStripe\Control\Controller::$basicAuthEnabled` - add this controller's url to `SilverStripe\Security\BasicAuthMiddleware.URLPatterns` injected property instead of setting false
+- Removed deprecated property `SilverStripe\Control\HTTP::$cache_age` - use [`SilverStripe\Control\Middleware\HTTPCacheControlMiddleware::setMaxAge()`](api:SilverStripe\Control\Middleware\HTTPCacheControlMiddleware::setMaxAge()) instead
 - Removed deprecated property `SilverStripe\Control\HTTP::$etag` - use [`SilverStripe\Control\Middleware\ChangeDetectionMiddleware`](api:SilverStripe\Control\Middleware\ChangeDetectionMiddleware) instead
 - Removed deprecated property `SilverStripe\Control\HTTP::$modification_date` - use [`SilverStripe\Control\Middleware\HTTPCacheControlMiddleware`](api:SilverStripe\Control\Middleware\HTTPCacheControlMiddleware) instead
-- Removed deprecated property `SilverStripe\Dev\Deprecation::$enabled` - use [`SilverStripe\Dev\Deprecation.currentlyEnabled`](api:SilverStripe\Dev\Deprecation.currentlyEnabled) instead
+- Removed deprecated property `SilverStripe\Dev\Deprecation::$enabled` - use `SilverStripe\Dev\Deprecation.currentlyEnabled` instead
 - Removed deprecated property `SilverStripe\Dev\Deprecation::$module_version_overrides` without equivalent functionality to replace it
 - Removed deprecated property `SilverStripe\Dev\Deprecation::$notice_level` without equivalent functionality to replace it
 - Removed deprecated property `SilverStripe\Dev\Deprecation::$version` without equivalent functionality to replace it
@@ -1562,28 +1562,28 @@ This sections contains the full list of APIs that have been changed or removed b
 - Removed deprecated class `SilverStripe\FullTextSearch\Search\Captures\SearchManipulateCapture_MySQLDatabase` - use `tractorcow/silverstripe-proxy-db` to proxy the database connector instead
 - Removed deprecated class `SilverStripe\FullTextSearch\Search\Captures\SearchManipulateCapture_PostgreSQLDatabase` - use `tractorcow/silverstripe-proxy-db` to proxy the database connector instead
 - Removed deprecated class `SilverStripe\FullTextSearch\Search\Captures\SearchManipulateCapture_SQLite3Database` - use `tractorcow/silverstripe-proxy-db` to proxy the database connector instead
-- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::exclude()` - use [`SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addExclude()`](api:SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addExclude()) instead
-- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::filter()` - use [`SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addFilter()`](api:SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addFilter()) instead
-- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::fuzzysearch()` - use [`SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addFuzzySearchTerm()`](api:SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addFuzzySearchTerm()) instead
-- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::inClass()` - use [`SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addClassFilter()`](api:SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addClassFilter()) instead
-- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::limit()` - use [`SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setLimit()`](api:SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setLimit()) instead
-- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::page()` - use [`SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setPageSize()`](api:SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setPageSize()) instead
-- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::search()` - use [`SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addSearchTerm()`](api:SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addSearchTerm()) instead
-- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::start()` - use [`SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setStart()`](api:SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setStart()) instead
-- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery_Range::end()` - use [`SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setEnd()`](api:SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setEnd()) instead
-- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery_Range::start()` - use [`SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setStart()`](api:SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setStart()) instead
-- Changed return type for [`SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::current()`](api:SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::current()) from dynamic to `mixed`
-- Changed return type for [`SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::key()`](api:SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::key()) from dynamic to `mixed`
-- Changed return type for [`SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::next()`](api:SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::next()) from dynamic to `void`
-- Changed return type for [`SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::rewind()`](api:SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::rewind()) from dynamic to `void`
-- Changed return type for [`SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::valid()`](api:SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::valid()) from dynamic to `bool`
-- Changed return type for [`SilverStripe\FullTextSearch\Utils\Logging\QueuedJobLogHandler::write()`](api:SilverStripe\FullTextSearch\Utils\Logging\QueuedJobLogHandler::write()) from dynamic to `void`
-- Changed return type for [`SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::current()`](api:SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::current()) from dynamic to `mixed`
-- Changed return type for [`SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::key()`](api:SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::key()) from dynamic to `mixed`
-- Changed return type for [`SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::next()`](api:SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::next()) from dynamic to `void`
-- Changed return type for [`SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::rewind()`](api:SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::rewind()) from dynamic to `void`
-- Changed return type for [`SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::valid()`](api:SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::valid()) from dynamic to `bool`
-- Changed parameter type in [`SilverStripe\FullTextSearch\Utils\Logging\QueuedJobLogHandler::write()`](api:SilverStripe\FullTextSearch\Utils\Logging\QueuedJobLogHandler::write()) for `$record` from `array` to `Monolog\LogRecord`
+- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::exclude()` - use `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addExclude()` instead
+- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::filter()` - use `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addFilter()` instead
+- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::fuzzysearch()` - use `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addFuzzySearchTerm()` instead
+- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::inClass()` - use `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addClassFilter()` instead
+- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::limit()` - use `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setLimit()` instead
+- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::page()` - use `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setPageSize()` instead
+- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::search()` - use `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::addSearchTerm()` instead
+- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::start()` - use `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setStart()` instead
+- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery_Range::end()` - use `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setEnd()` instead
+- Removed deprecated method `SilverStripe\FullTextSearch\Search\Queries\SearchQuery_Range::start()` - use `SilverStripe\FullTextSearch\Search\Queries\SearchQuery::setStart()` instead
+- Changed return type for `SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::current()` from dynamic to `mixed`
+- Changed return type for `SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::key()` from dynamic to `mixed`
+- Changed return type for `SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::next()` from dynamic to `void`
+- Changed return type for `SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::rewind()` from dynamic to `void`
+- Changed return type for `SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator::valid()` from dynamic to `bool`
+- Changed return type for `SilverStripe\FullTextSearch\Utils\Logging\QueuedJobLogHandler::write()` from dynamic to `void`
+- Changed return type for `SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::current()` from dynamic to `mixed`
+- Changed return type for `SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::key()` from dynamic to `mixed`
+- Changed return type for `SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::next()` from dynamic to `void`
+- Changed return type for `SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::rewind()` from dynamic to `void`
+- Changed return type for `SilverStripe\FullTextSearch\Utils\MultipleArrayIterator::valid()` from dynamic to `bool`
+- Changed parameter type in `SilverStripe\FullTextSearch\Utils\Logging\QueuedJobLogHandler::write()` for `$record` from `array` to `Monolog\LogRecord`
 
 ### silverstripe/graphql
 
@@ -1679,7 +1679,7 @@ This sections contains the full list of APIs that have been changed or removed b
 - Removed deprecated method `SilverStripe\MFA\Report\EnabledMembers::formatMethodsColumn()` - use [`SilverStripe\MFA\Extension\MemberExtension::getRegisteredMethodNames()`](api:SilverStripe\MFA\Extension\MemberExtension::getRegisteredMethodNames()) instead
 - Removed deprecated method `SilverStripe\MFA\Store\SessionStore::serialize()` - use [`SilverStripe\MFA\Store\SessionStore::__serialize()`](api:SilverStripe\MFA\Store\SessionStore::__serialize()) instead
 - Removed deprecated method `SilverStripe\MFA\Store\SessionStore::unserialize()` - use [`SilverStripe\MFA\Store\SessionStore::__unserialize()`](api:SilverStripe\MFA\Store\SessionStore::__unserialize()) instead
-- Changed return type for [`SilverStripe\MFA\RequestHandler\BaseHandlerTrait::getSudoModeService()`](api:SilverStripe\MFA\RequestHandler\BaseHandlerTrait::getSudoModeService()) from [`SilverStripe\SecurityExtensions\Service\SudoModeServiceInterface`](api:SilverStripe\SecurityExtensions\Service\SudoModeServiceInterface) to [`SilverStripe\Security\SudoMode\SudoModeServiceInterface`](api:SilverStripe\Security\SudoMode\SudoModeServiceInterface)
+- Changed return type for [`SilverStripe\MFA\RequestHandler\BaseHandlerTrait::getSudoModeService()`](api:SilverStripe\MFA\RequestHandler\BaseHandlerTrait::getSudoModeService()) from `SilverStripe\SecurityExtensions\Service\SudoModeServiceInterface` to [`SilverStripe\Security\SudoMode\SudoModeServiceInterface`](api:SilverStripe\Security\SudoMode\SudoModeServiceInterface)
 
 ### silverstripe/recipe-plugin
 
@@ -1704,8 +1704,8 @@ This sections contains the full list of APIs that have been changed or removed b
 
 - Removed deprecated class `SilverStripe\Subsites\Tasks\SubsiteMigrateFileTask` without equivalent functionality to replace it
 - Removed deprecated method `SilverStripe\Subsites\Extensions\SiteTreeSubsites::alternatePreviewLink()` - use [`SilverStripe\Subsites\Extensions\SiteTreeSubsites::updatePreviewLink()`](api:SilverStripe\Subsites\Extensions\SiteTreeSubsites::updatePreviewLink()) instead
-- Removed deprecated method `SilverStripe\Subsites\Model\Subsite::currentSubsiteID()` - use [`SilverStripe\Subsites\State\SubsiteState\SubsiteState::getSubsiteId()`](api:SilverStripe\Subsites\State\SubsiteState\SubsiteState::getSubsiteId()) instead
-- Removed deprecated property `SilverStripe\Subsites\Model\Subsite::$force_subsite` - use [`SilverStripe\Subsites\State\SubsiteState\SubsiteState::withState()`](api:SilverStripe\Subsites\State\SubsiteState\SubsiteState::withState()) instead.
+- Removed deprecated method `SilverStripe\Subsites\Model\Subsite::currentSubsiteID()` - use [`SilverStripe\Subsites\State\SubsiteState::getSubsiteId()`](api:SilverStripe\Subsites\State\SubsiteState::getSubsiteId()) instead
+- Removed deprecated property `SilverStripe\Subsites\Model\Subsite::$force_subsite` - use [`SilverStripe\Subsites\State\SubsiteState::withState()`](api:SilverStripe\Subsites\State\SubsiteState::withState()) instead.
 - Changed return type for [`SilverStripe\Subsites\Controller\SubsiteXHRController::getResponseNegotiator()`](api:SilverStripe\Subsites\Controller\SubsiteXHRController::getResponseNegotiator()) from dynamic to [`SilverStripe\Control\PjaxResponseNegotiator`](api:SilverStripe\Control\PjaxResponseNegotiator)
 - Changed return type for [`SilverStripe\Subsites\Model\Subsite::duplicate()`](api:SilverStripe\Subsites\Model\Subsite::duplicate()) from dynamic to `static`
 - Changed return type for [`SilverStripe\Subsites\State\SubsiteState::getSubsiteId()`](api:SilverStripe\Subsites\State\SubsiteState::getSubsiteId()) from dynamic to `int|null`
@@ -1739,12 +1739,12 @@ This sections contains the full list of APIs that have been changed or removed b
 
 ### silverstripe/vendor-plugin
 
-- Removed deprecated class `SilverStripe\VendorPlugin\VendorModule` - use [`SilverStripe\VendorPlugin\Library`](api:SilverStripe\VendorPlugin\Library) instead
-- Removed deprecated method `SilverStripe\VendorPlugin\Console\VendorExposeCommand::getAllModules()` - use [`SilverStripe\VendorPlugin\Console\VendorExposeCommand::getAllLibraries()`](api:SilverStripe\VendorPlugin\Console\VendorExposeCommand::getAllLibraries()) instead
+- Removed deprecated class `SilverStripe\VendorPlugin\VendorModule` - use `SilverStripe\VendorPlugin\Library` instead
+- Removed deprecated method `SilverStripe\VendorPlugin\Console\VendorExposeCommand::getAllModules()` - use `SilverStripe\VendorPlugin\Console\VendorExposeCommand::getAllLibraries()` instead
 - Removed deprecated method `SilverStripe\VendorPlugin\Library::installedIntoVendor()` without equivalent functionality to replace it
 - Removed deprecated method `SilverStripe\VendorPlugin\Library::publicPathExists()` without equivalent functionality to replace it
-- Removed deprecated method `SilverStripe\VendorPlugin\VendorPlugin::getVendorModule()` - use [`SilverStripe\VendorPlugin\VendorPlugin::getLibrary()`](api:SilverStripe\VendorPlugin\VendorPlugin::getLibrary()) instead
-- Removed deprecated constant `SilverStripe\VendorPlugin\Library::RESOURCES_PATH` - use [`SilverStripe\VendorPlugin\Library::getResourcesDir()`](api:SilverStripe\VendorPlugin\Library::getResourcesDir()) instead
+- Removed deprecated method `SilverStripe\VendorPlugin\VendorPlugin::getVendorModule()` - use `SilverStripe\VendorPlugin\VendorPlugin::getLibrary()` instead
+- Removed deprecated constant `SilverStripe\VendorPlugin\Library::RESOURCES_PATH` - use `SilverStripe\VendorPlugin\Library::getResourcesDir()` instead
 - Removed deprecated constant `SilverStripe\VendorPlugin\VendorPlugin::MODULE_FILTER` without equivalent functionality to replace it
 - Removed deprecated constant `SilverStripe\VendorPlugin\VendorPlugin::MODULE_TYPE` without equivalent functionality to replace it
 

--- a/en/04_Changelogs/5.0.0.md
+++ b/en/04_Changelogs/5.0.0.md
@@ -778,7 +778,7 @@ This sections contains the full list of APIs that have been changed or removed b
 
 ### silverstripe/asset-admin
 
-- Removed deprecated class `SilverStripe\AssetAdmin\Model\EmbedResource` - use [`SilverStripe\View\Embed\EmbedResource`](api:SilverStripe\View\Embed\EmbedResource) instead
+- Removed deprecated class `SilverStripe\AssetAdmin\Model\EmbedResource` - use [`SilverStripe\View\Embed\EmbedContainer`](api:SilverStripe\View\Embed\EmbedContainer) instead
 - Removed deprecated interface `SilverStripe\AssetAdmin\Model\Embeddable` - use [`SilverStripe\View\Embed\Embeddable`](api:SilverStripe\View\Embed\Embeddable) instead
 - Removed deprecated method `SilverStripe\AssetAdmin\Extensions\UsedOnTableExtension::updateUsage()` - use `updateUsageExcludedClasses()` instead
 - Changed return type for [`SilverStripe\AssetAdmin\BatchAction\DeleteAssets::run()`](api:SilverStripe\AssetAdmin\BatchAction\DeleteAssets::run()) from dynamic to [`SilverStripe\Control\HTTPResponse`](api:SilverStripe\Control\HTTPResponse)


### PR DESCRIPTION
## Description
Wrong links to api.silverstripe.org for unsupported modules have been removed.

## Parent issue
- https://github.com/silverstripe/developer-docs/issues/259