### PR TITLE
DOC Document using SSL for db connections

### DIFF
--- a/en/00_Getting_Started/03_Environment_Management.md
+++ b/en/00_Getting_Started/03_Environment_Management.md
@@ -109,6 +109,10 @@ Silverstripe core environment variables are listed here, though you're free to d
 | `SS_DATABASE_TIMEZONE`| Set the database timezone to something other than the system timezone.
 | `SS_DATABASE_NAME` | Set the database name. Assumes the `$database` global variable in your config is missing or empty. |
 | `SS_DATABASE_CHOOSE_NAME`| Boolean/Int. If defined, then the system will choose a default database name for you if one isn't give in the $database variable. The database name will be "SS_" followed by the name of the folder into which you have installed Silverstripe. If this is enabled, it means that the phpinstaller will work out of the box without the installer needing to alter any files. This helps prevent accidental changes to the environment. If `SS_DATABASE_CHOOSE_NAME` is an integer greater than one, then an ancestor folder will be used for the  database name. This is handy for a site that's hosted from /sites/examplesite/www or /buildbot/allmodules-2.3/build. If it's 2, the parent folder will be chosen; if it's 3 the grandparent, and so on.|
+| `SS_DATABASE_SSL_KEY` | Absolute path to SSL key file (optional - but if set, `SS_DATABASE_SSL_CERT` must also be set) |
+| `SS_DATABASE_SSL_CERT` | Absolute path to SSL certificate file (optional - but if set, `SS_DATABASE_SSL_KEY` must also be set) |
+| `SS_DATABASE_SSL_CA` | Absolute path to SSL Certificate Authority bundle file (optional) |
+| `SS_DATABASE_SSL_CIPHER` | Custom SSL cipher for database connections (optional) |
 | `SS_DEPRECATION_ENABLED` | Enable deprecation notices for this environment. `SS_ENVIRONMENT_TYPE` must be set to `dev` for deprecation notices to show. |
 | `SS_ENVIRONMENT_TYPE`| The environment type: dev, test or live.|
 | `SS_DEFAULT_ADMIN_USERNAME`| The username of the default admin. This is a user with administrative privileges.|

--- a/en/02_Developer_Guides/09_Security/04_Secure_Coding.md
+++ b/en/02_Developer_Guides/09_Security/04_Secure_Coding.md
@@ -797,6 +797,18 @@ Cookie::set('cookie-name', 'chocolate-chip', $expiry = 30, $path = null, $domain
 );
 ```
 
+### Using SSL in database connections
+
+In some circumstances, like connecting to a database on a remote host for example, you may wish to enable SSL encryption to ensure the protection of sensitive information and database access credentials.
+You can configure that by setting the following environment variables:
+
+| Name  | Description |
+| ----  | ----------- |
+| `SS_DATABASE_SSL_KEY` | Absolute path to SSL key file (optional - but if set, `SS_DATABASE_SSL_CERT` must also be set) |
+| `SS_DATABASE_SSL_CERT` | Absolute path to SSL certificate file (optional - but if set, `SS_DATABASE_SSL_KEY` must also be set) |
+| `SS_DATABASE_SSL_CA` | Absolute path to SSL Certificate Authority bundle file (optional) |
+| `SS_DATABASE_SSL_CIPHER` | Custom SSL cipher for database connections (optional) |
+
 ## Security Headers
 
 In addition to forcing HTTPS browsers can support additional security headers which can only allow access to a website 


### PR DESCRIPTION
This is a simplified version of the original docs in https://github.com/silverstripe/silverstripe-framework/pull/7254
I think the original went way overboard about how to set this all up - let's leave that documentation to mysql or whatever other db driver people want to use, and just document how to use the env vars on this end.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/8871