### PR TITLE
DOC Add note in 5.1 changelog about DB SSL

### DIFF
--- a/en/04_Changelogs/5.1.0.md
+++ b/en/04_Changelogs/5.1.0.md
@@ -22,6 +22,7 @@ title: 5.1.0 (unreleased)
 ## Bug fixes
 
 - [`DataList::filterAny()`](api:SilverStripe\ORM\DataList::filterAny()) queries on many-many relations that use an aggregate `HAVING` clause now correctly use an `OR` conjunction rather than an incorrect `AND` conjunction.
+- At some point shortly before the release of Silverstripe CMS 4.0.0, SSL support for database connections was accidentally removed. This has now been reinstated - see [Using SSL in database connections](/developer_guides/security/secure_coding#using-ssl-in-database-connections) for more information.
 
 This release includes a number of bug fixes to improve a broad range of areas. Check the change logs for full details of these fixes split by module. Thank you to the community members that helped contribute these fixes as part of the release!
 


### PR DESCRIPTION
The anchor in that link won't be valid until https://github.com/silverstripe/developer-docs/pull/271 is merged in and up - but that's going to happen way before we're ready to release so this can be merged without waiting for that to happen.

I know we don't often call out specific bug fixes in the changelog but this seems like one people ought to be aware of.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/8871