### PR TITLE
DOC Use correct class for keep_archived_assets config

### DIFF
--- a/en/02_Developer_Guides/14_Files/04_File_Storage.md
+++ b/en/02_Developer_Guides/14_Files/04_File_Storage.md
@@ -149,7 +149,7 @@ Changes are only tracked for file metadata (e.g. the `Title` attribute).
 You can opt-in to retaining the file content for replaced or removed files.
 
 ```yml
-SilverStripe\Assets\Flysystem\FlysystemAssetStore:
+SilverStripe\Assets\File:
   keep_archived_assets: true
 ```
 

--- a/en/02_Developer_Guides/14_Files/05_File_Migration.md
+++ b/en/02_Developer_Guides/14_Files/05_File_Migration.md
@@ -152,7 +152,7 @@ in order to avoid bloat. If you need to retain file contents (e.g. for auditing 
 you can opt-in to this behaviour:
 
 ```yaml
-SilverStripe\Assets\Flysystem\FlysystemAssetStore:
+SilverStripe\Assets\File:
   keep_archived_assets: true
 ```
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-versioned-admin/issues/300

FlysystemAssetStore is not a subclass of DataObject (which has the AssetControlExtension applied to it), and does not have the 'keep_archived_assets' config itself, so looks like this documentation was simply an error
