### PR TITLE
Revert "DOC Document storing gql schema in cache dir"

### DIFF
--- a/en/00_Getting_Started/00_Server_Requirements.md
+++ b/en/00_Getting_Started/00_Server_Requirements.md
@@ -89,9 +89,9 @@ also needs write access for the webserver user to the following locations:
   and [Partial Template Caching](/developer_guides/templates/partial_template_caching).
   See [Environment Management](/getting_started/environment_management).
 * `.graphql-generated`: silverstripe/graphql uses this directory. This is where your schema is
-  stored once it [has been built](/developer_guides/graphql/getting_started/building_the_schema/). Best practice
+  stored once it [has been built](/developer_guides/graphql/getting_started/building_the_schema). Best practice
   is to create it ahead of time, but if the directory doesn't exist and your project root is writable, the graphql
-  module will create it for you. Note that you can configure this to be stored elsewhere - see [building the schema](/developer_guides/graphql/getting_started/building_the_schema/#cache-location)
+  module will create it for you.
 * `public/_graphql`: silverstripe/graphql uses this directory. It's used for
   [schema introspection](/developer_guides/graphql/tips_and_tricks#schema-introspection). You should treat this folder
   the same way you treat the `.graphql-generated` folder.

--- a/en/02_Developer_Guides/19_GraphQL/01_getting_started/03_building_the_schema.md
+++ b/en/02_Developer_Guides/19_GraphQL/01_getting_started/03_building_the_schema.md
@@ -76,29 +76,6 @@ slow things down.
 To mitigate this, the generated code for each type is cached against a signature.
 If the type hasn't changed, it doesn't get re-built. This reduces build times to **under one second** for incremental changes.
 
-#### Choosing where the cache is stored {#cache-location}
-
-By default, the generated PHP code is placed in the `.graphql-generated/` directory in the root of your project.
-
-If you want to store this in another directory, you can configure this using the following yaml configuration. Note that the path is relative to your project root.
-
-```yml
-SilverStripe\GraphQL\Schema\Storage\CodeGenerationStore:
-  dirName: 'some/other/directory'
-```
-
-If you set the `dirName` configuration property to be blank, the schema will be stored in the `silverstripe-cache` (i.e. `TEMP_PATH`) directory. This can be useful
-if you have a mechanism that clear this folder on each deployment, or if you share this folder between servers in a multi-server setup, etc.
-
-```yml
-SilverStripe\GraphQL\Schema\Storage\CodeGenerationStore:
-  dirName: ''
-```
-
-[notice]
-Your schema will not be cleared on a normal system `flush`, even if you store it in the `silverstripe-cache` directory. See below to learn how to clear the schema.
-[/notice]
-
 #### Clearing the schema cache
 
 If you want to completely re-generate your schema from scratch, you can add `clear=1` to the `dev/graphql/build` command.
@@ -121,8 +98,8 @@ tangential changes such as:
 
 ### Viewing the generated code
 
-If you want to view your generated code, you can find it in the directory it has been configured to build in. See [choosing where the cache is stored](#cache-location) above.
-It is not meant to be accessible through your webserver, which is ensured by keeping it outside of the
+By default, the generated PHP code is placed in the `.graphql-generated/` directory in the root of your project.
+It is not meant to be accessible through your webserver, Which is ensured by keeping it outside of the
 `public/` webroot and the inclusion of a `.htaccess` file in each schema folder.
 
 Additional files are generated for CMS operation in `public/_graphql/`, and

--- a/en/02_Developer_Guides/19_GraphQL/01_getting_started/05_deploying_the_schema.md
+++ b/en/02_Developer_Guides/19_GraphQL/01_getting_started/05_deploying_the_schema.md
@@ -10,10 +10,6 @@ icon: rocket
 
 ## Deploying the schema
 
-[info]
-For simplicity, this documentation assumes you are using the default `.graphql-generated/` to store your generated schema - but note that this can be configured to be any path relative to your project root. See [choosing where the cache is stored](/developer_guides/graphql/getting_started/building_the_schema/#cache-location) for more information.
-[/info]
-
 One way or another, you must get the `.graphql-generated/` and `public/_graphql/` folders into your test and production environments for Silverstripe CMS (and your own custom queries) to work as expected. There are many ways to do so. The options below are listed in order of complexity.
 
 ### Single-server hosting solutions with simple deployments {#simple-single-server}

--- a/en/04_Changelogs/5.1.0.md
+++ b/en/04_Changelogs/5.1.0.md
@@ -9,7 +9,6 @@ title: 5.1.0 (unreleased)
 - [Security considerations](#security-considerations)
 - [Features and enhancements](#features-and-enhancements)
   - [Eager loading](#eager-loading)
-  - [GraphQL schema can be stored in `silverstripe-cache`](#gql-schema-is-cache)
   - [Improvement to page search performance with Elemental](#cms-search-performance)
   - [New `InheritedPermissions` option - only these members](#only-these-members)
   - [Optimised queries when filtering against IDs](#filter-by-ids)
@@ -66,14 +65,6 @@ foreach ($teams as $team) {
 ```
 
 Read more about [eager loading](/developer_guides/model/relations/#eager-loading) including its limitations in the developer docs.
-
-### GraphQL schema can be stored in `silverstripe-cache` {#gql-schema-is-cache}
-
-By default, the graphql schema is stored in a `.graphql-generated/` directory in your project root. It is now possible to configure this to be stored in the `silverstripe-cache` (i.e. `TEMP_PATH`) directory.
-
-Note that even if you store the schema in the cache directory, the schema still won't be invalidated when you flush the cache. See [what triggers a GraphQL code build](/developer_guides/graphql/getting_started/building_the_schema/#what-triggers-a-graphql-code-build) for details about how to build the schema.
-
-See [choosing where the cache is stored](/developer_guides/graphql/getting_started/building_the_schema/#cache-location) for more information about configuring the schema storage directory.
 
 ### Improvement to page search performance with Elemental {#cms-search-performance}
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-graphql/issues/547

This reverts commit 7796becdc1e4d616224fc7c49ea557707895db29.