### PR TITLE
DOC Document changes from silverstripe/silverstripe-framework#10925

### DIFF
--- a/en/02_Developer_Guides/00_Model/02_Relations.md
+++ b/en/02_Developer_Guides/00_Model/02_Relations.md
@@ -709,7 +709,7 @@ Eager loading is only intended to be used in read-only scenarios such as when ou
 
 Note that filtering or sorting an `EagerLoadedList` will be done in PHP rather than as part of the database query, since we have already loaded all its relevant data into memory.
 
-Note also that `EagerLoadedList` can't currently filter or sort by fields on relations using dot syntax (e.g. `sort('MySubRelation.Title')` won't work), nor filter using [`SearchFilter` syntax](/developer_guides/model/searchfilters/) (e.g. `filter('Title:StartsWith', 'Prefix')`).
+Note also that `EagerLoadedList` can't currently filter or sort by fields on relations using dot syntax (e.g. `sort('MySubRelation.Title')` won't work).
 [/notice]
 
 ## Cascading deletions

--- a/en/02_Developer_Guides/00_Model/06_SearchFilters.md
+++ b/en/02_Developer_Guides/00_Model/06_SearchFilters.md
@@ -6,7 +6,7 @@ icon: search
 
 # SearchFilter Modifiers
 
-The [`filter()`](api:SilverStripe\ORM\DataList::filter()) and [`exclude()`](api:SilverStripe\ORM\DataList::exclude()) methods on `DataList` specify exact matches by default. However, when filtering a `DataList`, there are a number of suffixes that
+The `filter()`, `exclude()`, and other related methods on [`DataList`](api:SilverStripe\ORM\DataList), [`ArrayList`](api:SilverStripe\ORM\ArrayList), and [`EagerLoadedList`](api:SilverStripe\ORM\EagerLoadedList) specify exact matches by default. However, when calling these methods, there are a number of suffixes that
 you can put on field names to change this behavior. These are represented as `SearchFilter` subclasses and include:
 
  * [ExactMatchFilter](api:SilverStripe\ORM\Filters\ExactMatchFilter)
@@ -37,7 +37,7 @@ $players = Player::get()->filterAny([
 ```
 
 [hint]
-Notice the syntax - to invoke a `SearchFilter` in a `DataList`'s `filter()`/`filterAny()`/`filterByCallback()` or `exclude()`/`excludeAny()` methods, you add a colon after the field name, followed by the name of the filter (excluding the actual word "filter"). e.g. for a `StartsWithFilter`: `'FieldName:StartsWith'`
+Notice the syntax - to invoke a `SearchFilter` in the `filter()`/`filterAny()`/`find()` or `exclude()`/`excludeAny()` methods, you add a colon after the field name, followed by the name of the filter (excluding the actual word "filter"). e.g. for a `StartsWithFilter`: `'FieldName:StartsWith'`
 [hint]
 
 Developers can define their own [SearchFilter](api:SilverStripe\ORM\Filters\SearchFilter) if needing to extend the ORM filter and exclude behaviors.
@@ -45,9 +45,24 @@ Developers can define their own [SearchFilter](api:SilverStripe\ORM\Filters\Sear
 ## Modifiers
 
 `SearchFilter`s can also take modifiers. The modifiers currently supported are `":not"`, `":nocase"`, and
-`":case"` (though you can implement custom modifiers on your own `SearchFilter` implementations). These negate the filter, make it case-insensitive and make it case-sensitive, respectively. The default
-comparison uses the database's default. For MySQL and MSSQL, this is case-insensitive. For PostgreSQL, this is
-case-sensitive.
+`":case"` (though you can implement custom modifiers on your own `SearchFilter` implementations). These negate the filter, make it case-insensitive and make it case-sensitive, respectively.
+
+[info]
+The default comparison uses the database's default case sensitivity. For MySQL and MSSQL, this is case-insensitive. For PostgreSQL, this is case-sensitive. But you can declare the default
+case sensitivity for your project by setting the `default_case_sensitive` configuration property on `SearchFilter` like so:
+
+```yml
+SilverStripe\ORM\Filters\SearchFilter:
+  default_case_sensitive: false
+```
+
+Though note that for backwards compatibility reasons, `ArrayList` is explicitly case sensitive by default. To change that, you must set `ArrayList.default_case_sensitive` to false.
+
+```yml
+SilverStripe\ORM\ArrayList:
+  default_case_sensitive: false
+```
+[/info]
 
 ```php
 // Fetch players that their FirstName is exactly 'Sam'

--- a/en/04_Changelogs/5.1.0.md
+++ b/en/04_Changelogs/5.1.0.md
@@ -9,6 +9,7 @@ title: 5.1.0 (unreleased)
 - [Security considerations](#security-considerations)
 - [Features and enhancements](#features-and-enhancements)
   - [Eager loading](#eager-loading)
+  - [ArrayList improvements](#arraylist-improvements)
   - [Improvement to page search performance with Elemental](#cms-search-performance)
   - [New `InheritedPermissions` option - only these members](#only-these-members)
   - [Optimised queries when filtering against IDs](#filter-by-ids)
@@ -66,6 +67,12 @@ foreach ($teams as $team) {
 ```
 
 Read more about [eager loading](/developer_guides/model/relations/#eager-loading) including its limitations in the developer docs.
+
+### ArrayList improvements
+
+- You can now use [`SearchFilter` syntax](/developer_guides/model/searchfilters/) when calling any of the filter or exclude methods on [`ArrayList`](api:SilverStripe\ORM\ArrayList).
+- For backwards compatibility, `ArrayList` filters are explicitly case sensitive by default. This differs from `DataList` which uses the database configuration to determine its default case sensitivity. See [search filter modifiers](/developer_guides/model/searchfilters/#modifiers) for more details including how to configure this for your project.
+- [`ArrayList`](api:SilverStripe\ORM\ArrayList) now has an [`excludeAny()`](api:SilverStripe\ORM\ArrayList::excludeAny()) method, which mirrors the [`DataList::excludeAny()`](api:SilverStripe\ORM\DataList::excludeAny()) method.
 
 ### Improvement to page search performance with Elemental {#cms-search-performance}
 
@@ -136,6 +143,7 @@ SilverStripe\SessionManager\Models\LoginSession:
 
 - [`BuildTask`](api:SilverStripe\Dev\BuildTask) now has boolean `is_enabled` configuration option which has precedence over the existing `BuildTask::enabled` protected class property. The `BuildTask::enabled` property has been marked as deprecated and will be removed in CMS 6 if favour of using `is_enabled` instead.
 - Passing an argument for `$limit` that is not `array|string|null` in [`SilverStripe\ORM\Search\SearchContext::getQuery()`](api:SilverStripe\ORM\Search\SearchContext::getQuery()) will throw a deprecation warning. In CMS 6 the parameter type will be changed from dynamic to `array|string|null`.
+- You can now declare the default case sensitivity used by `SearchFilter` implementations, which power the `DataList` filtering functionality. See [search filter modifiers](/developer_guides/model/searchfilters/#modifiers) for more details.
 
 ### silverstripe/elemental-fileblock
 


### PR DESCRIPTION
The following acceptance criteria don't really make sense so I won't be doing them:

- "Document the prefered approach of creating new filters that work with both SQL and non-SQL filtering"
  - There's no advice for implementing new search filters at all already - I imagine anyone who wants to do this will be able to tell pretty quickly what methods they need to implement.
- "Document how to register new filters that work with DataList and other non-SQL list."
  - There's no difference between registering for one purpose or the other. All search filters that are configured per the current documentation will work for both purposes, if they have been implemented for those purposes.

## Issue 
- https://github.com/silverstripe/silverstripe-framework/issues/5911