### PR TITLE
MNT Update branch which builds docs site

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - '3'
       - '4.13'
-      - '5.0'
+      - '5.1'
 jobs:
   build:
     name: build-docs


### PR DESCRIPTION
Updates the branch which triggers deploying docs.silverstripe.org

Note: This is targetting `5` because that's the default branch - this would not actually do anything if it targetted `5.1`

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/803