### PR TITLE
DOCS Add missing word "guide" to "User Help guide"

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -22,7 +22,7 @@ Silverstripe has a wide range of options for getting support:
 * Join our [forum](https://forum.silverstripe.org)
 * Ask technical questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/silverstripe)
 * Read the technical reference in our [API Documentation](https://api.silverstripe.org/)
-* Get a user-focused overview of the CMS features in our [User Help](https://userhelp.silverstripe.com)
+* Get a user-focused overview of the CMS features in our [User Help guide](https://userhelp.silverstripe.com)
 * Discuss new features, API changes and the development [roadmap](https://www.silverstripe.org/software/roadmap/)
   on the ["feature ideas" category](https://forum.silverstripe.org/c/feature-ideas) in our forums
 


### PR DESCRIPTION
This is how it is described on the first page of the user help guide, and is a clearer name than simply "User Help".