### PR TITLE
DOC add errorpage allowed_error_codes to 5.2.0 changelog

### DIFF
--- a/en/04_Changelogs/5.2.0.md
+++ b/en/04_Changelogs/5.2.0.md
@@ -7,11 +7,26 @@ title: 5.2.0 (unreleased)
 ## Overview
 
 - [Features and enhancements](#features-and-enhancements)
+  - [ErrorPage allowed codes configuration](#errorpage-allowed-codes-configuration)
   - [Other new features](#other-new-features)
 - [API changes](#api-changes)
 - [Bug fixes](#bug-fixes)
 
 ## Features and enhancements
+
+### ErrorPage allowed codes configuration
+
+By default, all available error codes are present in the dropdown in the CMS. This can be overwhelming and there are a few (looking at you, 418) that can
+be confusing. To that end, you can limit the codes in the dropdown with the config value `allowed_error_codes` like so:
+
+```yml
+SilverStripe\ErrorPage\ErrorPage:
+  allowed_error_codes:
+    - 400
+    - 403
+    - 404
+    - 500
+```
 
 ### Other new features
 


### PR DESCRIPTION
Accompaniment to https://github.com/silverstripe/silverstripe-errorpage/pull/91