### PR TITLE
DOC Add clarification about benchmark results

### DIFF
--- a/en/04_Changelogs/5.1.0.md
+++ b/en/04_Changelogs/5.1.0.md
@@ -141,14 +141,16 @@ SilverStripe\ORM\DataList:
   use_placeholders_for_integer_ids: true
 ```
 
-The following performance improvements were measured in a test setup where 10,000 record IDs were passed in:
+The following performance improvements were measured in a test setup where 10,000 record IDs were passed into a direct call to the methods indicated below:
 - DataList::byIDs() - 198% faster - (0.0608s vs 0.1812s)
 - RelationList::foreignIDFilter()
   - HasManyList::foreignIDFilter() - 108% faster (0.1584s vs 0.3304s)
   - ManyManyList::foreignIDFilter() - 108% faster (0.1529s vs 0.3119s)
   - ManyManyThroughList::foreignIDFilter() - 27% faster (0.6901s vs 0.8766s)
 
-Note that those observations were made using MySQL.
+Please note that this _does not_ mean that your `has_many` relation queries will be 108% faster for example, as those queries do not typically pass a large number of IDs to the `foreignIDFilter()` method.
+
+Note that these observations were made using MySQL.
 
 ### Session manager changes {#session-manager}
 


### PR DESCRIPTION
Just clarifying that the benchmark does _not_ say anything about actual relation queries, because the way it was written implied (to me at least, so probably to others as well) that the actual relation queries would _also_ be significantly faster.

I did another benchmark, this time checking explicitly the actual relation queries.
The setup was identical to the one mentioned in https://github.com/silverstripe/developer-docs/issues/330#issuecomment-1689246562 except the `many_many` definition on `MyDataObject` was fixed so that the many many through relation actually worked:
```php
private static $many_many = [
    'MyManyDataObjects' => MyManyDataObject::class,
    'MyManyThroughDataObjects' => [
        'through' => MyThroughDataObject::class,
        'from' => self::class,
        'to' => MyManyThroughDataObject::class,
    ]
];
```
and the actual running of the tests looked like this:
```php
Versioned::set_reading_mode('Stage.Stage');
$s = microtime(true);

// has_one
// foreach (MyDataObject::get() as $do) {
//     $do->MyOneDataObject()->Title;
// }
/*
    WITH optimisation:
    0.0595, 0.0592, 0.0627, 0.0592, 0.0649 (avg 0.0611)
    WITHOUT optimisation:
    0.0552, 0.0592, 0.0649, 0.0602, 0.0584 (avg 0.05958)
*/

// has_many
// foreach (MyDataObject::get() as $do) {
//     $do->MySubDataObjects()->toArray();
// }
/*
    WITH optimisation:
    0.3394, 0.3505, 0.3363, 0.3319, 0.3587 (avg 0.34336)
    WITHOUT optimisation:
    0.3474, 0.3448, 0.3554, 0.3452, 0.3581 (avg 0.35018)
*/

// many_many
// foreach (MyDataObject::get() as $do) {
//     $do->MyManyDataObjects()->toArray();
// }
/*
    WITH optimisation:
    0.3816, 0.3744, 0.3568, 0.3649, 0.3543 (avg 0.3664)
    WITHOUT optimisation:
    0.3564, 0.3591, 0.3695, 0.3570, 0.3747 (avg 0.36334)
*/

// many_many through
// foreach (MyDataObject::get() as $do) {
//     $do->MyManyThroughDataObjects()->toArray();
// }
/*
    WITH optimisation:
    0.9710, 0.9668, 0.9506, 0.9980, 0.9668 (avg 0.97064)
    WITHOUT optimisation:
    0.9782, 0.9761, 0.9653, 0.9892, 0.9960 (avg 0.98096)
*/

$t = microtime(true) - $s;
printf('%0.4f', $t);
die;
```
As you can see, there was no significant difference for these queries with or without the optimisation applied.

## Issue
- https://github.com/silverstripeltd/product-issues/issues/816