### PR TITLE
DOC Fix broken syntax

### DIFF
--- a/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/01_adding_dataobjects_to_the_schema.md
+++ b/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/01_adding_dataobjects_to_the_schema.md
@@ -204,15 +204,16 @@ A couple things to note here:
 
 * By assigning a value of `true` to the field, we defer to the model to infer the type for the field. To override that, we can always add a `type` property:
 
-```yaml
-MyProject\Models\Product:
-  fields:
-    onSale:
-      type: Boolean
-```
+    ```yaml
+    MyProject\Models\Product:
+      fields:
+        onSale:
+          type: Boolean
+    ```
 
 * The mapping of our field names to the `DataObject` property is case-insensitive. It is a
 convention in GraphQL APIs to use lowerCamelCase fields, so this is given by default.
+
 [/notice]
 
 ### Bulk loading models
@@ -239,9 +240,9 @@ elemental: # An arbitrary key to define what these directives are doing
   load:
     inheritanceLoader:
       include:
-          - DNADesign\Elemental\Models\BaseElement
+        - DNADesign\Elemental\Models\BaseElement
       exclude:
-          - MyApp\Elements\MySecretElement
+        - MyApp\Elements\MySecretElement
   # Add all fields and read operations
   apply:
     fields:


### PR DESCRIPTION
The notice and the nested code block are rendering incorrectly:

![image](https://github.com/silverstripe/developer-docs/assets/36352093/64420ad4-7583-4413-bfa5-6c9583610be7)

## Issue
- https://github.com/silverstripe/developer-docs/issues/363