### PR TITLE
DOC Make error log file path absolute

### DIFF
--- a/en/03_Upgrading/07_Deprecations.md
+++ b/en/03_Upgrading/07_Deprecations.md
@@ -55,7 +55,7 @@ SilverStripe\Core\Injector\Injector:
   ErrorLogFileHandler:
     class: Monolog\Handler\StreamHandler
     constructor:
-      - "var/www/silverstripe.log"
+      - "/var/www/silverstripe.log"
       - "warning" # warning is the level deprecation warnings are logged as
   Psr\Log\LoggerInterface.errorhandler:
     calls:


### PR DESCRIPTION
The error log file path must be absolute as per https://docs.silverstripe.org/en/developer_guides/debugging/error_handling/#logging-to-a-file

## Issue
- https://github.com/silverstripe/developer-docs/issues/363