### PR TITLE
DOC Remove references to quarterly releases.

### DIFF
--- a/en/05_Contributing/04_Release_Process.md
+++ b/en/05_Contributing/04_Release_Process.md
@@ -55,11 +55,11 @@ All Silverstripe CMS recipes are released in lock step with each other. For exam
 contain `silverstripe/recipe-cms` 4.3.1 and `silverstripe/recipe-core` 4.3.1. These recipes may contain various patch
 versions of its modules within the same minor release line (4.3 in this example).
 
-## Regular quarterly releases
+## Regular minor releases
 
-A regular Silverstripe CMS release is tagged on a quarterly basis, in the months: March, June, September, December. This usually involves creating a new minor increment of 
-each core recipe. Regular quarterly releases are preceded by pre-stable releases to help lay the groundwork for the
-stable release.
+Regular minor releases are preceded by pre-stable releases to help lay the groundwork for the stable release.
+
+See our [minor release policy](/project_governance/minor_release_policy/) for details about our release cadence.
 
 ### Beta phase
 


### PR DESCRIPTION
Any other changes to this page are explicitly out of scope as noted on the linked issue.

## Issue
- https://github.com/silverstripe/developer-docs/issues/360