### PR TITLE
MNT Fix typo in linting rule options

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -35,7 +35,7 @@
     <rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing">
         <properties>
             <property name="linesCountBeforeNamespace" value="0"/>
-            <property name="linesCountBAfterNamespace" value="1"/>
+            <property name="linesCountAfterNamespace" value="1"/>
         </properties>
     </rule>
 


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/developer-docs/issues/419