### PR TITLE
DOC Update percentages for eagerloading benchmark

### DIFF
--- a/en/04_Changelogs/5.1.0.md
+++ b/en/04_Changelogs/5.1.0.md
@@ -146,10 +146,10 @@ foreach ($teams as $team) {
 
 In a test setup with looping through 100 DataObjects each with 100 related DataObjects for a total of 10,000 records per test run, the following performance improvements were observed for different types of relations (eager-loading vs not eager-loading):
 
-- HasOne - 3227% faster (0.0078s vs 0.2595s)
-- HasMany - 25% faster (0.1453s vs 0.1819s)
-- ManyMany - 25% faster (0.1664s vs 0.2083s)
-- ManyManyThrough - 16% faster (0.6586s vs 0.7681s)
+- HasOne - ~97% faster (0.0078s vs 0.2595s)
+- HasMany - ~20% faster (0.1453s vs 0.1819s)
+- ManyMany - ~20% faster (0.1664s vs 0.2083s)
+- ManyManyThrough - ~14% faster (0.6586s vs 0.7681s)
 
 Note that those observations were made using MySQL.
 


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/documentation/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe the changes you're making, and the reason for making them.
  For visual fixes, please include tested browsers and screenshots.
-->
While working on https://github.com/silverstripe/silverstripe-framework/issues/10929 I had to do some benchmarking, and I wanted to validate my findings against the ones that were done for 5.1.

The percentages don't seem to be correct - this PR updates them based on https://www.calculatorsoup.com/calculators/algebra/percent-change-calculator.php

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-framework/issues/10929