### PR TITLE
DOC Fix placement of urlfield docs

### DIFF
--- a/en/08_Changelogs/5.2.0.md
+++ b/en/08_Changelogs/5.2.0.md
@@ -266,15 +266,15 @@ Both of these fields include a `setIsLazyLoaded()` method which will load a limi
 
 Note that these are both powered by react components, and are only intended to be used within the CMS. If you want to use them on the front-end of your project you will need to provide your own templates and JavaScript implementation for them.
 
-### New `UrlField` {#urlfield}
-
-A new [`UrlField`](api:SilverStripe\Forms\UrlField) has been added which is a subclass of [`TextField`](api:SilverStripe\Forms\TextField) with some additional validation rules. It will validate that the value entered is a valid absolute URL with a protocol and a host.
-
 #### Auto scaffolding of `has_one` relations
 
 A `SearchableDropdownField` will now be used when automatically scaffolding `has_one` relations on a form in the CMS. Previously a `DropdownField` was used, and when there were over 100 items a [`NumericField`](api:SilverStripe\Forms\NumericField) was used which was not user friendly.
 
 Previously the [`DBForeignKey.dropdown_field_threshold`](api:SilverStripe\ORM\FieldType\DBForeignKey->dropdown_field_threshold) config property was used as the threshold of the number of options to decide when to switch between auto-scaffolding a `DropdownField` and a `NumericField`. This configuration property is now used as the threshold of the number of options to decide when to start using lazy-loading for the `SearchableDropdownField`.
+
+### New `UrlField` {#urlfield}
+
+A new [`UrlField`](api:SilverStripe\Forms\UrlField) has been added which is a subclass of [`TextField`](api:SilverStripe\Forms\TextField) with some additional validation rules. It will validate that the value entered is a valid absolute URL with a protocol and a host.
 
 ### Create file variants with different extensions {#file-variants}
 


### PR DESCRIPTION
The "Auto scaffolding of `has_one` relations" heading should be under the searchable fields stuff, not under the url field stuff.

## Issue
- https://github.com/silverstripe/developer-docs/issues/459