### PR TITLE
DOC Document LTS support for databases

### DIFF
--- a/en/00_Getting_Started/00_Server_Requirements.md
+++ b/en/00_Getting_Started/00_Server_Requirements.md
@@ -26,6 +26,8 @@ You also need to install [Composer 2](https://getcomposer.org/).
 
 ## Database
 
+We officially support and regression test against the LTS releases of MySQL and MariaDB, though we may choose to support additional versions on a case-by-case basis.
+
 - MySQL >=5.6 (built-in, [commercially supported](/project_governance/supported_modules/))
 - PostgreSQL ([third party module](https://github.com/silverstripe/silverstripe-postgresql), community
   supported)


### PR DESCRIPTION
This indicates what to expect, but gives us a way to provide additional support if we deem it necessary (e.g. I could see people wanting MySQL 9 support before the LTS for that release line).

Note the issue only mentions mariadb, but MySQL is rolling out releases quarterly (see ["MySQL Versions Release Cadence" on this page](https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions/#:~:text=MySQL%20Versions%20Release%20Cadence)) which we obviously can't keep up with since we do releases every 6 months.

## Issue
- https://github.com/silverstripe/.github/issues/202