### PR TITLE
DOC Document new parameter for `DataObject::write()`

### DIFF
--- a/en/08_Changelogs/6.0.0.md
+++ b/en/08_Changelogs/6.0.0.md
@@ -6,10 +6,16 @@ title: 6.0.0 (unreleased)
 
 ## Overview
 
-- [Run `CanonicalURLMiddleware` in all environments by default](#url-middleware)
+- [Features and enhancements](#features-and-enhancements)
+  - [Run `CanonicalURLMiddleware` in all environments by default](#url-middleware)
+  - [Other new features](#other-new-features)
 - [Bug fixes](#bug-fixes)
+- [API changes](#api-changes)
+  - [General changes](#api-general)
 
-## Run `CanonicalURLMiddleware` in all environments by default {#url-middleware}
+## Features and enhancements
+
+### Run `CanonicalURLMiddleware` in all environments by default {#url-middleware}
 
 In Silverstripe CMS 5 [`CanonicalURLMiddleware`](api:SilverStripe\Control\Middleware\CanonicalURLMiddleware) only runs in production by default. This lead to issues with `fetch` and APIs behaving differently in production environments to development. Silverstripe 6.0 changes this default to run the rules in `dev`, `test`, and `live` by default.
 
@@ -24,9 +30,17 @@ CanonicalURLMiddleware::singleton()->setEnabledEnvs([
 ]);
 ```
 
+### Other new features
+
 ## Bug fixes
 
 This release includes a number of bug fixes to improve a broad range of areas. Check the change logs for full details of these fixes split by module. Thank you to the community members that helped contribute these fixes as part of the release!
+
+## API changes
+
+### General changes {#api-general}
+
+- [`DataObject::write()`](api:SilverStripe\ORM\DataObject::write()) has a new boolean `$skipValidation` parameter. This can be useful for scenarios where you want to automatically create a new record with no data initially without restricting how developers can set up their validation rules.
 
 <!--- Changes below this line will be automatically regenerated -->
 


### PR DESCRIPTION
Also slightly restructured the changelog to be more like the 5.0.0 one was

## Issues
- https://github.com/silverstripe/silverstripe-elemental/issues/1149