### PR TITLE
DOC Change hint to tip

### DIFF
--- a/en/02_Developer_Guides/03_Forms/01_Validation.md
+++ b/en/02_Developer_Guides/03_Forms/01_Validation.md
@@ -6,7 +6,7 @@ icon: check-square
 
 # Form validation
 
-> [!HINT]
+> [!TIP]
 > Before you start implementing custom validation logic, check out [validation using `symfony/validator` constraints](/developer_guides/model/validation/#validation-and-constraints)
 > and see if there's an existing constraint that can do the heavy lifting for you.
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/developer-docs/issues/503

I searched for `[!HINT]` in dev docs, only one match which is fixed in this PR