### PR TITLE
DOC Update `cascade_deletes` information for `has_many` relationships

### DIFF
--- a/en/02_Developer_Guides/00_Model/02_Relations.md
+++ b/en/02_Developer_Guides/00_Model/02_Relations.md
@@ -991,7 +991,7 @@ class ParentObject extends DataObject
 
 In this example, when the parent object is deleted, the child specified by the `has_one` relation will also be deleted. The relation types `has_many`, `belongs_to`, and `has_one` are supported, as are methods that return lists of objects but do not correspond to a physical database relation.
 
-### Cascading deletions with `has_many`
+### Cascading deletions for `many_many` relations
 
 When the parent object is deleted, the end child specified by the `cascade_deletes` will also be removed, not unlinked. To remove the link between the two objects, use `has_many` on the relation object directly to create an alternate view of the relationship which can be unlinked.
 

--- a/en/02_Developer_Guides/00_Model/02_Relations.md
+++ b/en/02_Developer_Guides/00_Model/02_Relations.md
@@ -989,11 +989,13 @@ class ParentObject extends DataObject
 }
 ```
 
-In this example, when the parent object is deleted, the child specified by the `has_one` relation will also be deleted. The relation types `has_many`, `belongs_to`, and `has_one` are supported, as are methods that return lists of objects but do not correspond to a physical database relation.
+In this example, when the parent object is deleted, the child specified by the `has_one` relation will also be deleted.
+
+All relation types (`has_many`, `many_many`, `belongs_many_many`, `belongs_to`, and `has_one`) are supported, as are methods that return lists of objects but do not correspond to a physical database relation. In all cases the child defined in `cascade_deletes` will be deleted, never unlinked.
 
 ### Cascading deletions for `many_many` relations
 
-When the parent object is deleted, the end child specified by the `cascade_deletes` will also be removed, not unlinked. To remove the link between the two objects, use `has_many` on the relation object directly to create an alternate view of the relationship which can be unlinked.
+When the parent object is deleted, the end child specified by the `cascade_deletes` will also be removed, not unlinked. To remove just the link between the two objects, use `has_many` on the relation object directly to create an alternate view of the relationship which can be unlinked.
 
 For example:
 
@@ -1026,6 +1028,8 @@ class Team extends DataObject
     // ...
 }
 ```
+
+This will avoid the situation where related children used by many data objects are removed from all parents because a single parent was deleted.
 
 ### Cascading deletions with versions
 

--- a/en/02_Developer_Guides/00_Model/02_Relations.md
+++ b/en/02_Developer_Guides/00_Model/02_Relations.md
@@ -1019,7 +1019,7 @@ class Team extends DataObject
     ];
 
     // Unlink the relationship when the parent object is deleted
-    private static array $cascade_duplicates = [
+    private static array $cascade_deletes = [
         'SupportersRelation',
     ];
 

--- a/en/02_Developer_Guides/00_Model/02_Relations.md
+++ b/en/02_Developer_Guides/00_Model/02_Relations.md
@@ -997,6 +997,8 @@ All relation types (`has_many`, `many_many`, `belongs_many_many`, `belongs_to`, 
 
 When the parent object is deleted, the end child specified by the `cascade_deletes` will also be removed, not unlinked. To remove just the link between the two objects, use `has_many` on the relation object directly to create an alternate view of the relationship which can be unlinked.
 
+Note that this requires using the [`many_many` through](#many-many-through) style relation. A regular `many_many` relation cannot be used this way.
+
 For example:
 
 ```php

--- a/en/02_Developer_Guides/00_Model/02_Relations.md
+++ b/en/02_Developer_Guides/00_Model/02_Relations.md
@@ -989,9 +989,45 @@ class ParentObject extends DataObject
 }
 ```
 
-In this example, when the parent object is deleted, the child specified by the `has_one` relation will also
-be deleted. Note that all relation types (`has_many`, `many_many`, `belongs_many_many`, `belongs_to`, and `has_one`)
-are supported, as are methods that return lists of objects but do not correspond to a physical database relation.
+In this example, when the parent object is deleted, the child specified by the `has_one` relation will also be deleted. The relation types `has_many`, `belongs_to`, and `has_one` are supported, as are methods that return lists of objects but do not correspond to a physical database relation.
+
+### Cascading deletions with `has_many`
+
+When the parent object is deleted, the end child specified by the `cascade_deletes` will also be removed, not unlinked. To remove the link between the two objects, use `has_many` on the relation object directly to create an alternate view of the relationship which can be unlinked.
+
+For example:
+
+```php
+namespace App\Model;
+
+use SilverStripe\ORM\DataObject;
+
+class Team extends DataObject
+{
+    // Define the many-to-many relationship using a custom relation table
+    private static array $many_many = [
+        'Supporters' => [
+            'through' => TeamSupporter::class,
+            'from' => 'Team',
+            'to' => 'Supporter',
+        ],
+    ];
+
+    // Add a different perspective of the relationship data
+    private static array $has_many = [
+        'SupportersRelation' => TeamSupporter::class . '.Team',
+    ];
+
+    // Unlink the relationship when the parent object is deleted
+    private static array $cascade_duplicates = [
+        'SupportersRelation',
+    ];
+
+    // ...
+}
+```
+
+### Cascading deletions with versions
 
 If your object is versioned, `cascade_deletes` will also act as "cascade unpublish", such that any unpublish
 on a parent object will trigger unpublish on the child, similarly to how `owns` causes triggered publishing.

--- a/en/02_Developer_Guides/00_Model/02_Relations.md
+++ b/en/02_Developer_Guides/00_Model/02_Relations.md
@@ -991,7 +991,7 @@ class ParentObject extends DataObject
 
 In this example, when the parent object is deleted, the child specified by the `has_one` relation will also be deleted.
 
-All relation types (`has_many`, `many_many`, `belongs_many_many`, `belongs_to`, and `has_one`) are supported, as are methods that return lists of objects but do not correspond to a physical database relation. In all cases the child defined in `cascade_deletes` will be deleted, never unlinked.
+All relation types (`has_many`, `many_many`, `belongs_many_many`, `belongs_to`, and `has_one`) are supported, as are methods that return lists of objects but do not correspond to a physical database relation. In all cases the child defined in `cascade_deletes` will be deleted.
 
 ### Cascading deletions for `many_many` relations
 


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/documentation/ if you haven't contributed to this project recently.
-->
## Description

Given that [this issue](https://github.com/silverstripe/silverstripe-framework/issues/9612) has been open for some time, we should update the documentation which is giving incorrect information to developers.

I have added an example of how best to manage `cascade_deletes` between `many_many` related objects.

To avoid adding confusion, I decided against adding the alternative solution using `onBeforeDelete()` and `removeAll()`. However this can also be added if you think it is needed, or better?

## Issues
- https://github.com/silverstripe/silverstripe-framework/issues/9612

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [branches and commit messages](https://docs.silverstripe.org/en/contributing/documentation#branches-and-commit-messages)
- [x] All commits are relevant to the purpose of the PR (e.g. no TODO comments, unrelated rewording/restructuring, or arbitrary changes)
    - Small amounts of additional changes are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/documentation/)
- [x] The changes follow our [writing style guide](https://docs.silverstripe.org/en/contributing/documentation/#writing-style)
- [x] Code examples follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] CI is green
