### PR TITLE
DOC Remove Guy Marriott from Core Committers page

### DIFF
--- a/en/12_Project_Governance/01_Core_committers.md
+++ b/en/12_Project_Governance/01_Core_committers.md
@@ -14,7 +14,6 @@ This page outlines those who are part of the Core Committer team and outlines th
 
 - [Aaron Carlino](https://github.com/unclecheese/)
 - [Garion Herman](https://github.com/cheddam)
-- [Guy Marriott](https://github.com/ScopeyNZ)
 - [Guy Sartorelli](https://github.com/GuySartorelli)
 - [Ingo Schommer](https://github.com/chillu)
 - [Loz Calver](https://github.com/kinglozzer)


### PR DESCRIPTION
@ScopeyNZ has decided to leave the Core Committers group. Thank you for everything you've done for Silverstripe CMS and its community!

Core Committers can check https://silverstripe-users.slack.com/archives/G33BPFV6J/p1718848782952419 to verify.

## Issue
- https://github.com/silverstripe/developer-docs/issues/537