### PR TITLE
DOC Add autologin token regeneration changes to 5.3 changelog

### DIFF
--- a/en/08_Changelogs/5.3.0.md
+++ b/en/08_Changelogs/5.3.0.md
@@ -12,6 +12,7 @@ title: 5.3.0 (unreleased)
   - [Validation for elemental content blocks when saving individual blocks](#elemental-validation)
   - [Define scaffolded form fields for relations to `DataObject` models](#scaffolded-relation-formfields)
   - [Support for `JOIN` in SQL `UPDATE`](#sql-update-join)
+  - [Autologin token regeneration changes](#autologin-token-regeneration)
   - [Other new features](#other-new-features)
   - [API changes](#api-changes)
 - [Bug fixes](#bug-fixes)
@@ -109,6 +110,21 @@ The [`SQLUpdate`](api:SilverStripe\ORM\Queries\SQLUpdate) class now supports all
 
 This is particularly helpful if you need to update columns in one table to match values from another table.
 
+### Autologin token regeneration changes {#autologin-token-regeneration}
+
+The Autologin ('remember me') feature stores cookies in the user's browser to allow recreation of their session when it expires. Currently, one of the cookies is regenerated whenever a user's session is recreated. This can cause unexpected logouts in certain situations, and has minimal value from a security standpoint.
+
+In 5.3, the current behaviour is retained, but can be disabled via configuration:
+
+```yml
+SilverStripe\Security\RememberLoginHash:
+  replace_token_during_session_renewal: false
+```
+
+This will cause the token to be generated once during login, and not be regenerated during session renewal.
+
+From 6.0 onwards, tokens will never be regenerated during session renewal, and this configuration will be removed.
+
 ### Other new features
 
 - `silverstripe/linkfield` now has improved accessibility support for screen readers and keyboard navigation. Focus states have also been made consistent between keyboard and mouse interaction.
@@ -120,6 +136,9 @@ This is particularly helpful if you need to update columns in one table to match
 
 - Passing a non-array `$fields` argument to both [`FieldList::addFieldsToTab()`](api:SilverStripe\Forms\FieldList::addFieldsToTab()) and [`FieldList::removeFieldsFromTab()`](api:SilverStripe\Forms\FieldList::removeFieldsFromTab()) has been deprecated.
 - The [`BaseElement::getDescription()`](api:DNADesign\Elemental\Models\BaseElement::getDescription()) method has been deprecated. To update the description of elemental blocks, use the [`description`](api:DNADesign\Elemental\Models\BaseElement->description) configuration property and the localisation API.
+- The [`RememberLoginHash::renew()`](api:SilverStripe\Security\RememberLoginHash::renew()) method has been deprecated without replacement, since the associated behaviour will be removed in 6.0.
+  - The `onAfterRenewToken` extension point within this method will likely be replaced with a new extension point in 6.0.
+- The [`RememberLoginHash.replace_token_during_session_renewal`](api:SilverStripe\Security\RememberLoginHash->replace_token_during_session_renewal) configuration property has been added to allow disabling token regeneration during session renewal. This property will be removed in 6.0.
 
 ## Bug fixes
 


### PR DESCRIPTION
## Description

Adds details regarding https://github.com/silverstripe/silverstripe-framework/pull/11299 to the 5.3 changelog.

## Issues

- https://github.com/silverstripe/silverstripe-framework/issues/11281

## Pull request checklist

- [x] The target branch is correct
    - See [branches and commit messages](https://docs.silverstripe.org/en/contributing/documentation#branches-and-commit-messages)
- [x] All commits are relevant to the purpose of the PR (e.g. no TODO comments, unrelated rewording/restructuring, or arbitrary changes)
    - Small amounts of additional changes are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/documentation/)
- [x] The changes follow our [writing style guide](https://docs.silverstripe.org/en/contributing/documentation/#writing-style)
- [x] Code examples follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] CI is green
