### PR TITLE
DOC Fixing the URL for React Dev tools

### DIFF
--- a/en/02_Developer_Guides/15_Customising_the_Admin_Interface/08_ReactJS_Redux_and_GraphQL.md
+++ b/en/02_Developer_Guides/15_Customising_the_Admin_Interface/08_ReactJS_Redux_and_GraphQL.md
@@ -60,7 +60,7 @@ to the React API. While optional, it is recommended to express components this w
 
 ### Recommended: react dev tools
 
-The [React Dev Tools](https://chrome.g.oogle.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en) extension available for Chrome and Firefox is critical to debugging a React UI. It will let you browse the React UI much like the DOM, showing the tree of rendered components and their current props and state in real time.
+The React Dev Tools extension available for [Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en) and [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/react-devtools/) is critical to debugging a React UI. It will let you browse the React UI much like the DOM, showing the tree of rendered components and their current props and state in real time.
 
 ## Redux
 

--- a/en/02_Developer_Guides/15_Customising_the_Admin_Interface/08_ReactJS_Redux_and_GraphQL.md
+++ b/en/02_Developer_Guides/15_Customising_the_Admin_Interface/08_ReactJS_Redux_and_GraphQL.md
@@ -60,7 +60,7 @@ to the React API. While optional, it is recommended to express components this w
 
 ### Recommended: react dev tools
 
-The React Dev Tools extension available for [Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en) and [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/react-devtools/) is critical to debugging a React UI. It will let you browse the React UI much like the DOM, showing the tree of rendered components and their current props and state in real time.
+The React Dev Tools extension [available for Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en) [and for Firefox](https://addons.mozilla.org/en-GB/firefox/addon/react-devtools/) is critical to debugging a React UI. It will let you browse the React UI much like the DOM, showing the tree of rendered components and their current props and state in real time.
 
 ## Redux
 


### PR DESCRIPTION
## Description
The URL for the React Dev Tools had a bad URL in it. This PR does the following

- Fixes that URL
- Moves the link to be directly connect with the word `Chrome` 
- Adds a link to the Firefox Dev tools

## Issues

- #618 

## Pull request checklist

- [x] The target branch is correct
    - See [branches and commit messages](https://docs.silverstripe.org/en/contributing/documentation#branches-and-commit-messages)
- [x] All commits are relevant to the purpose of the PR (e.g. no TODO comments, unrelated rewording/restructuring, or arbitrary changes)
    - Small amounts of additional changes are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/documentation/)
- [x] The changes follow our [writing style guide](https://docs.silverstripe.org/en/contributing/documentation/#writing-style)
- [x] Code examples follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] CI is green
