### PR TITLE
DOC Remove "unreleased" from 5.3.0 changelog

### DIFF
--- a/en/08_Changelogs/5.3.0.md
+++ b/en/08_Changelogs/5.3.0.md
@@ -1,8 +1,4 @@
----
-title: 5.3.0 (unreleased)
----
-
-# 5.3.0 (unreleased)
+# 5.3.0
 
 ## Overview
 


### PR DESCRIPTION
Forgot to remove this before letting cow do the release.
Note that depending on when this gets merged, there may not be enough runners to deploy, so deployment may need to be done manually.

## Issue
- https://github.com/silverstripeltd/product-issues/issues/878