### PR TITLE
DOC Add PHP 8.4 support

### DIFF
--- a/en/00_Getting_Started/00_Server_Requirements.md
+++ b/en/00_Getting_Started/00_Server_Requirements.md
@@ -12,7 +12,7 @@ the server to update templates, website logic, and perform upgrades or maintenan
 
 ## PHP
 
-- PHP 8.3
+- PHP 8.3 - 8.4
 - PHP extensions: `ctype`, `dom`, `fileinfo`, `hash`, `intl`, `mbstring`, `session`, `simplexml`, `tokenizer`, `xml`
 - PHP configuration: `memory_limit` with at least `48M`
 - PHP extension for image manipulation: Either `gd` or `imagick`
@@ -273,7 +273,7 @@ table may be of use:
 
 | Silverstripe CMS Version | PHP Version |
 | ------------------------ | ----------- |
-| 6.0 +                    | 8.3         |
+| 6.0 +                    | 8.3 - 8.4   |
 | 5.2 +                    | 8.1 - 8.3   |
 | 5.0 - 5.1                | 8.1 - 8.2   |
 

--- a/en/00_Getting_Started/index.md
+++ b/en/00_Getting_Started/index.md
@@ -8,7 +8,7 @@ icon: rocket
 
 ## Server requirements
 
-Silverstripe requires PHP 8.3 or newer. It runs on many webservers and databases, but is most commonly served using
+Silverstripe requires PHP 8.3 or PHP 8.4. It runs on many webservers and databases, but is most commonly served using
 Apache and MySQL/MariaDB.
 
 If you are setting up your own environment, you'll need to consider a few configuration settings such as URL rewriting

--- a/en/08_Changelogs/6.0.0.md
+++ b/en/08_Changelogs/6.0.0.md
@@ -37,6 +37,7 @@ title: 6.0.0 (unreleased)
   - [List interface changes](#list-interface-changes)
   - [General changes](#api-general)
 - [Other changes](#other-changes)
+  - [PHP version support](#php-version-support)
   - [MySQL 5 no longer supported](#mysql-5-support)
   - [MySQL now defaults to utf8mb4](#mysql-utf8mb4)
   - [`DBDecimal` default value](#dbdecimal-default-value)
@@ -1004,6 +1005,10 @@ As part of these changes [`ArrayList::find()`](api:SilverStripe\Model\List\Array
 - [`DBCurrency`](api:SilverStripe\ORM\FieldType\DBCurrency) will no longer parse numeric values contained in a string when calling `setValue()`. For instance "this is 50.29 dollars" will no longer be converted to "$50.29", instead its value will remain as "this is 50.29 dollars" and it will throw a validation exception if attempted to be written to the database.
 
 ## Other changes
+
+### PHP version support {#php-version-support}
+
+Silverstripe CMS 6 requires either PHP 8.3 or PHP 8.4. PHP 8.1 and PHP 8.2 which were supported in Silverstripe CMS 5 are no longer supported.
 
 ### MySQL 5 no longer supported {#mysql-5-support}
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/331

I don't think we should add a changelog entry for this as it's PHP 8.4 support is simply something that CMS 6 comes with.

If we did want to mention this in the changelog then it seems like we'd need to mention that PHP 8.1 and 8.2 are no longer supported i.e. it's a change from CMS 5