### PR TITLE
MNT Add 6.0 to list of branches to build docs site

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
       - '3'
       - '4.13'
       - '5.3'
+      - '6.0'
 jobs:
   build:
     name: build-docs


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/.github/issues/340