### PR TITLE
DOC Note that API links are broken for now

### DIFF
--- a/en/08_Changelogs/6.0.0.md
+++ b/en/08_Changelogs/6.0.0.md
@@ -4,6 +4,9 @@ title: 6.0.0 (unreleased)
 
 # 6.0.0 (unreleased)
 
+> [!WARNING]
+> The API links in this changelog are currently non-functional. We are working to resolve this.
+
 ## Overview
 
 - [Change to commercially supported modules](#changes-to-support)

--- a/en/08_Changelogs/alpha/6.0.0-alpha1.md
+++ b/en/08_Changelogs/alpha/6.0.0-alpha1.md
@@ -1,5 +1,8 @@
 # 6.0.0-alpha1
 
+> [!WARNING]
+> The API links in this changelog are currently non-functional. We are working to resolve this.
+
 ## Overview
 
 - [Change to commercially supported modules](#changes-to-support)
@@ -1130,6 +1133,8 @@ If you were calling `getSchemaData()` in your `getAttributes()` method in a `For
 ```
 
 ### Full list of removed and changed API (by module, alphabetically) {#api-removed-and-changed}
+
+<!-- markdownlint-disable proper-names enhanced-proper-names title-case-style -->
 
 <details>
 <summary>Reveal full list of API changes</summary>
@@ -2401,7 +2406,7 @@ If you were calling `getSchemaData()` in your `getAttributes()` method in a `For
   - 2024-09-10 [a0ad75397](https://github.com/silverstripe/silverstripe-framework/commit/a0ad753974b5904746e05b4a028b0caeedfb0ceb) Create DBClassNameVarchar (Steve Boyd)
   - 2024-08-25 [e3508d41d](https://github.com/silverstripe/silverstripe-framework/commit/e3508d41d520983262e2fba28f7b6db0785e6d72) Provide a standardised CMSEditLink method (#11338) (Guy Sartorelli)
   - 2024-08-15 [64a17e09d](https://github.com/silverstripe/silverstripe-framework/commit/64a17e09d4eb66da7e17902d6c0f7d9b0e2d2340) Various changes to support SiteTree form field scaffolding (#11327) (Guy Sartorelli)
-  - 2024-07-01 [98dc238d2](https://github.com/silverstripe/silverstripe-framework/commit/98dc238d2aec1558a604941f6fc608c789702e03) Do not require _config dir or _config.php for modules (Steve Boyd)
+  - 2024-07-01 [98dc238d2](https://github.com/silverstripe/silverstripe-framework/commit/98dc238d2aec1558a604941f6fc608c789702e03) Do not require _config dir or `_config.php` for modules (Steve Boyd)
   - 2024-06-26 [a684c8ca0](https://github.com/silverstripe/silverstripe-framework/commit/a684c8ca03badc0a6462581aca23c68a1e45d5f7) Auto-scaffold Member and Group with appropriate form fields (#11285) (Guy Sartorelli)
   - 2024-05-24 [3f30da515](https://github.com/silverstripe/silverstripe-framework/commit/3f30da5155af6165627cfb6d7b6c19888fd58613) Looping through arrays in templates (#11244) (Guy Sartorelli)
   - 2024-04-18 [dcc686340](https://github.com/silverstripe/silverstripe-framework/commit/dcc68634018ca9b8dd442cd74812addbf7b4988a) Allow skipping validation on write (#11202) (Guy Sartorelli)
@@ -3361,7 +3366,7 @@ If you were calling `getSchemaData()` in your `getAttributes()` method in a `For
   - 2024-07-23 [bbacccf6](https://github.com/silverstripe/developer-docs/commit/bbacccf6b58dbc9d81af4d2598c4f4c7de48d87c) Document upgrading intervention/image (#547) (Guy Sartorelli)
   - 2024-07-12 [5b4516f5](https://github.com/silverstripe/developer-docs/commit/5b4516f549684607cd6144afefaf3736d44de6f5) Document changes to caching (#543) (Guy Sartorelli)
   - 2024-07-02 [0541b0e9](https://github.com/silverstripe/developer-docs/commit/0541b0e98c3e45ed0697d32c6ae8b617775b5ac5) Document changes to scaffolded fields (#540) (Guy Sartorelli)
-  - 2024-07-01 [21fe47c5](https://github.com/silverstripe/developer-docs/commit/21fe47c594553063b3e7a58489315f582515c3ea) Modules no longer need to have a _config.php file or _config directory (Steve Boyd)
+  - 2024-07-01 [21fe47c5](https://github.com/silverstripe/developer-docs/commit/21fe47c594553063b3e7a58489315f582515c3ea) Modules no longer need to have a _config.php file or `_config` directory (Steve Boyd)
   - 2024-06-11 [beeb3e3e](https://github.com/silverstripe/developer-docs/commit/beeb3e3e29de34232c9dadf8fe82e3e88dc1bcbd) Document removal of BaseElement::getDescription() (#531) (Guy Sartorelli)
   - 2024-05-24 [72d0ed5e](https://github.com/silverstripe/developer-docs/commit/72d0ed5e14a6548b989c3aa60fe83a692b8593b1) Document ability to loop over arrays in templates (#517) (Guy Sartorelli)
   - 2024-05-22 [a3cc2d80](https://github.com/silverstripe/developer-docs/commit/a3cc2d80307a3499a3fdfe31f360c7640d8ddad4) Protected extension hook implementations in changelog (Steve Boyd)


### PR DESCRIPTION
We're having some issues with api.silverstripe.org not updating right now. We'll sort that out but don't want it to block the alpha release comms.

## Issue
- https://github.com/silverstripe/.github/issues/340