### PR TITLE
DOC Document changes to template functionality

### DIFF
--- a/en/08_Changelogs/6.0.0.md
+++ b/en/08_Changelogs/6.0.0.md
@@ -604,14 +604,10 @@ To improve the separation between the view and model layers (and in some cases a
 
 - Added a new [`ViewLayerData`](api:SilverStripe\View\ViewLayerData) class which sits between the template layer and the model layer. All data that gets used in the template layer gets wrapped in a `ViewLayerData` instance first. This class provides a consistent API and value lookup logic so that all data gets treated the same way once it's in the template layer.
 - Move casting logic into a new [`CastingService`](api:SilverStripe\View\CastingService) class. This class is responsible for casting data to the correct model (e.g. by default strings get cast to [`DBText`](api:SilverStripe\ORM\FieldType\DBText) and booleans get cast to [`DBBoolean`](api:SilverStripe\ORM\FieldType\DBBoolean)). If the source of the data is known and is an instance of `ModelData`, the casting service calls [`ModelData::castingHelper()`](api:SilverStripe\Model\ModelData:castingHelper()) to ensure the [`ModelData.casting`](api:SilverStripe\Model\ModelData->casting) configuration and (in the case of `DataObject`) the db schema are taken into account.
-  - Native indexed PHP arrays can now be passed into templates and iterated over with `<% loop $MyArray %>`. Under the hood they are wrapped in [`ArrayList`](api:SilverStripe\Model\List\ArrayList), so you can get the count using `$Count` and use `<% if $MyArray %>` as a shortcut for `<% if $MyArray.Count %>`. Other functionality from `ArrayList` such as filtering and sorting cannot be used on these arrays since they don't have keys to filter or sort against.
 - Implemented a default [`ModelData::forTemplate()`](api:SilverStripe\Model\ModelData::forTemplate()) method which will attempt to render the model using templates named after it and its superclasses. See [`forTemplate` and `$Me`](/developer_guides/templates/syntax/#fortemplate) for information about this method's usage.
   - [`ModelDataCustomised::forTemplate()`](SilverStripe\Model\ModelDataCustomised::forTemplate()) explicitly uses the `forTemplate()` method of the class being customised, not from the class providing the customisation.
 - The `ModelData::XML_val()` method has been removed as it is no longer needed to get values for usage in templates.
-- Arguments are now passed into getter methods when invoked in templates. For example, if a model has a `getMyField(..$args)` method and `$MyField(1,2,3)` is used in a template, the args `1, 2, 3` will be passed in to the `getMyField()` method.
-  - For parity, the [`ModelData::obj()`](api:SilverStripe\Model\ModelData::obj()) method now also passes arguments into getter methods. Note however that this method is no longer used to get values in the template layer.
-- Values from template variables are passed into functions when used as arguments
-  - For example, `$doSomething($Title)` will pass the value of the `Title` property into the `doSomething()` method. See [template syntax](/developer_guides/templates/syntax/#variables) documentation for more details.
+- The [`ModelData::obj()`](api:SilverStripe\Model\ModelData::obj()) method now also passes arguments into getter methods. Note however that this method is no longer used to get values in the template layer.
 - The [`ModelData::objCacheSet()`](api:SilverStripe\Model\ModelData::objCacheSet()) and [`ModelData::objCacheGet()`](api:SilverStripe\Model\ModelData::objCacheGet()) methods now deal with raw values prior to being cast. This is so that `ViewLayerData` can use the cache reliably.
 - Nothing in core or supported modules (except for the template engine itself) relies on absolute file paths for templates - instead, template names and relative paths (without the `.ss` extension) are used.
   - [`Email::getHTMLTemplate()`](SilverStripe\Control\Email\Email::getHTMLTemplate()) now returns an array of template candidates, unless a specific template was set using `setHTMLTemplate()`.
@@ -661,6 +657,16 @@ Along with those API changes, the following classes and interfaces were moved in
 |`SilverStripe\View\TemplateParser`|[`SilverStripe\TemplateEngine\TemplateParser`](api:SilverStripe\TemplateEngine\TemplateParser)|
 
 If you want to just keep using the ss template syntax you're familiar with, you shouldn't need to change anything (except as specified in other sections or if you were using API that has moved or been removed).
+
+##### Changes to template functionality
+
+The following changes have been made to the way templates work.
+
+- Native indexed PHP arrays can now be passed into templates and iterated over with `<% loop $MyArray %>`. Under the hood they are wrapped in [`ArrayList`](api:SilverStripe\Model\List\ArrayList), so you can get the count using `$MyArray.Count` and use `<% if $MyArray %>` as a shortcut for `<% if $MyArray.Count %>`. Other functionality from `ArrayList` such as filtering and sorting cannot be used on these arrays since they don't have keys to filter or sort against.
+- Arguments are now passed into getter methods when invoked in templates. For example, if a model has a `getMyField(...$args)` method and `$MyField(1,2,3)` is used in a template, the args `1, 2, 3` will be passed in to the `getMyField()` method.
+- Values from template variables are passed into functions when used as arguments
+  - For example, `$doSomething($Title)` will pass the value of the `Title` property into the `doSomething()` method. See [template syntax](/developer_guides/templates/syntax/#variables) documentation for more details.
+- The old `<% _t("My_KEY", "Default text") %>` and `<% sprintf(_t("My_KEY", "Default text with %s"), "replacement") %>` i18n syntaxes have been removed. Use the syntax described in the [i18n documentation](/developer_guides/i18n/#usage-in-template-files) instead.
 
 #### Strong typing for `ModelData` and `DBField`
 


### PR DESCRIPTION
Mostly documents https://github.com/silverstripe/silverstripe-template-engine/pull/6 but also moves some content into a new section that just talks about the changes to template syntax, since that seems a sensible grouping of information.

## Issue
- https://github.com/silverstripe/.github/issues/311