### PR TITLE
DOC Deprecate passing null paramters for Form and ValidationResult methods

### DIFF
--- a/en/08_Changelogs/5.4.0.md
+++ b/en/08_Changelogs/5.4.0.md
@@ -322,6 +322,17 @@ See [indexes](/developer_guides/model/indexes/) to learn about indexes in Silver
 - The [`HTTP.ignoreDeprecatedCaching`](api:SilverStripe\Control\HTTP->ignoreDeprecatedCaching) configuration property has been deprecated. It will be removed without equivalent functionality to replace it.
 - [`FormField::Value()`](api:SilverStripe\Forms\FormField::Value()) has been deprecated. It will be replaced by getFormattedValue() and getValue().
 - [`TextareaField::ValueEntities()`](api:SilverStripe\Forms\TextareaField::ValueEntities()) has been deprecated. It will be replaced by getFormattedValueEntities().
+- Passing `null` for the `$code` parameter in [`ValidationResult::addError()`](api:SilverStripe\ORM\ValidationResult::addError()) is deprecated. Pass a blank string instead.
+- Passing `null` for the `$cast` parameter in [`ValidationResult::addError()`](api:SilverStripe\ORM\ValidationResult::addError()) is deprecated. Pass a ValidationResult::CAST_* constant instead.
+- Passing `null` for the `$code` parameter in [`ValidationResult::addFieldError()`](api:SilverStripe\ORM\ValidationResult::addFieldError()) is deprecated. Pass a blank string instead.
+- Passing `null` for the `$cast` parameter in [`ValidationResult::addFieldError()`](api:SilverStripe\ORM\ValidationResult::addFieldError()) is deprecated. Pass a ValidationResult::CAST_* constant instead.
+- Passing `null` for the `$code` parameter in [`ValidationResult::addMessage()`](api:SilverStripe\ORM\ValidationResult::addMessage()) is deprecated. Pass a blank string instead.
+- Passing `null` for the `$cast` parameter in [`ValidationResult::addMessage()`](api:SilverStripe\ORM\ValidationResult::addMessage()) is deprecated. Pass a ValidationResult::CAST_* constant instead.
+- Passing `null` for the `$code` parameter in [`ValidationResult::addFieldMessage()`](api:SilverStripe\ORM\ValidationResult::addFieldMessage()) is deprecated. Pass a blank string instead.
+- Passing `null` for the `$cast` parameter in [`ValidationResult::addFieldMessage()`](api:SilverStripe\ORM\ValidationResult::addFieldMessage()) is deprecated. Pass a ValidationResult::CAST_* constant instead.
+- Passing `null` for the `$cast` parameter in [`Form::sessionMessage()`](api:SilverStripe\Forms\Form::sessionMessage()) is deprecated. Pass a ValidationResult::CAST_* constant instead.
+- Passing `null` for the `$cast` parameter in [`Form::sessionError()`](api:SilverStripe\Forms\Form::sessionError()) is deprecated. Pass a ValidationResult::CAST_* constant instead.
+- Passing `null` for the `$cast` parameter in [`Form::sessionFieldError()`](api:SilverStripe\Forms\Form::sessionFieldError()) is deprecated. Pass a ValidationResult::CAST_* constant instead.
 
 ## Bug fixes
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11423