### PR TITLE
Remove "warning" about "fulltextsearch"

### DIFF
--- a/en/02_Developer_Guides/12_Search/02_FulltextSearch.md
+++ b/en/02_Developer_Guides/12_Search/02_FulltextSearch.md
@@ -10,11 +10,6 @@ Fulltext search allows advanced search criteria for searching words within a tex
 Fulltext search can be achieved using the built-in [MySQLDatabase](api:SilverStripe\ORM\Connect\MySQLDatabase) class a more powerful wrapper for Fulltext
 search is provided through a module.
 
-> [!WARNING]
-> See the [FulltextSearch Module](https://github.com/silverstripe-labs/silverstripe-fulltextsearch/). This module provides
-> a high level wrapper for running advanced search services such as Solr, Lucene or Sphinx in the backend rather than
-> `MySQL` search.
-
 ## Adding fulltext support to `MySQLDatabase`
 
 The [MySQLDatabase](api:SilverStripe\ORM\Connect\MySQLDatabase) class defaults to creating tables using the InnoDB storage engine. As Fulltext search in MySQL


### PR DESCRIPTION
The "silverstripe-labs" fulltextsearch module is incredibly outdated, and relies on a very outdated not-vendorized library. The security and stability of this module is questionable at best, and should not be suggested

<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/documentation/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe the changes you're making, and the reason for making them.
  For visual fixes, please include tested browsers and screenshots.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [branches and commit messages](https://docs.silverstripe.org/en/contributing/documentation#branches-and-commit-messages)
- [x] All commits are relevant to the purpose of the PR (e.g. no TODO comments, unrelated rewording/restructuring, or arbitrary changes)
    - Small amounts of additional changes are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/documentation/)
- [x] The changes follow our [writing style guide](https://docs.silverstripe.org/en/contributing/documentation/#writing-style)
- [x] Code examples follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] CI is green
