### PR TITLE
DOC Document warning for allowed hosts

### DIFF
--- a/en/08_Changelogs/5.4.0.md
+++ b/en/08_Changelogs/5.4.0.md
@@ -8,6 +8,7 @@ title: 5.4.0 (unreleased)
 
 - [Security considerations](#security-considerations)
 - [Features and enhancements](#features-and-enhancements)
+  - [Logged warning if allowed hosts have not been configured](#allowed-hosts-warning)
   - [New `XssSanitiser` class](#new-xsssanitiser-class)
   - [Option to change `ClassName` column from enum to varchar](#classname-varchar)
   - [Reports quality of life updates](#reports-quality-of-life-updates)
@@ -31,6 +32,25 @@ We have provided a severity rating of the vulnerabilities below based on the CVS
 - [SS-2024-002 - Reflected Cross Site Scripting (XSS) in error message](https://www.silverstripe.org/download/security-releases/ss-2024-002) Severity: None
 
 ## Features and enhancements
+
+### Logged warning if allowed hosts have not been configured {#allowed-hosts-warning}
+
+If your site does not have one of the following configured, then a warning will now be logged on every request:
+
+- `SS_ALLOWED_HOSTS` environment variable
+- [`AllowedHostsMiddleware.AllowedHosts`](api:SilverStripe\Control\Middleware\AllowedHostsMiddleware->AllowedHosts) property
+
+The "host" header is used by Silverstripe CMS to determine what the host name is for your project. This is useful when creating absolute URLs, e.g. for use in emails.
+
+Notably this is used in [`Director::host()`](api:SilverStripe\Control\Director::host()), which in turn is called by many methods including [`Director::hostName()`](api:SilverStripe\Control\Director::hostName()), [`Director::protocolAndHost()`](api:SilverStripe\Control\Director::protocolAndHost()), [`Director::is_site_url()`](api:SilverStripe\Control\Director::is_site_url()), and [`Director::absoluteURL()`](api:SilverStripe\Control\Director::absoluteURL()).
+
+Ideally your hosting will reject invalid host headers. For example Apache allows you to define valid hosts as part of the virtual host configuration, and a Web Application Firewall (WAF) can also be configured to validate the host header. However if your hosting is set to allow *any* host header, your project might be vulnerable to host header injection attacks.
+
+You should configure Silverstripe CMS to validate the host header, which is an extra layer of protection against this type of attack. While you should have appropriate validation at a hosting level, it is best practice to also configure this in your project.
+
+This configuration has existed since 2016, but we've been alerted that many projects still have not configured their hosting nor their project to adequately validate host headers. To help prompt developers, we've added a warning which will be logged if the configuration is not set.
+
+You can learn more about the relevant configuration in the [secure coding](/developer_guides/security/secure_coding/#request-hostname-forgery) documentation.
 
 ### New `XssSanitiser` class
 


### PR DESCRIPTION
Also some reworking on the related configuration to improve clarity, make sure everything is fully documented, and updates to the reverse proxy docs which was just wrong in some cases.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11610