### PR TITLE
DOC Update link to view available font icons

### DIFF
--- a/en/02_Developer_Guides/15_Customising_the_Admin_Interface/01_ModelAdmin.md
+++ b/en/02_Developer_Guides/15_Customising_the_Admin_Interface/01_ModelAdmin.md
@@ -231,7 +231,7 @@ class NewsAdmin extends ModelAdmin
 }
 ```
 
-A complete list of supported font icons is available to view in the [Silverstripe CMS Design System Manager](https://projects.invisionapp.com/dsm/silver-stripe/silver-stripe/section/icons/5a8b972d656c91001150f8b6)
+A complete list of supported font icons is available to view in the [Silverstripe pattern library](https://silverstripe.github.io/silverstripe-pattern-lib/?path=/story/admin-icons--icon-reference).
 
 ## Searching records
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/developer-docs/issues/735

I've validated with a quick script that fonts-reference.html has 250 font-icon's, just like _fonts.scss in silverstripe/admin does.

```php
$patha = __DIR__ . '/vendor/silverstripe/admin/client/src/font/icons-reference.html';
$pathb = __DIR__ . '/vendor/silverstripe/admin/client/src/styles/_fonts.scss';

$ca = file_get_contents($patha);
$cb = file_get_contents($pathb);

preg_match_all('# class="icon font\-icon\-#', $ca, $ma);
echo 'ma ' . count($ma[0]) . PHP_EOL;

preg_match_all('#\.font\-icon\-#', $cb, $mb);
echo 'mb ' . count($mb[0]) . PHP_EOL;

// ma 250
// mb 250
```