### PR TITLE
DOC Changelog entry for site tree performance improvements

### DIFF
--- a/en/08_Changelogs/6.0.0.md
+++ b/en/08_Changelogs/6.0.0.md
@@ -13,6 +13,7 @@ title: 6.0.0 (unreleased)
   - [Validation added to DBFields](#dbfield-validation)
   - [Changes to `sake`, `BuildTask`, CLI interaction in general](#cli-changes)
   - [Read-only replica database support](#db-read-only-replicas)
+  - [Performance improvements for site tree rendering](#site-tree-performance)
   - [Run `CanonicalURLMiddleware` in all environments by default](#url-middleware)
   - [Changes to default cache adapters](#caching)
   - [Changes to scaffolded form fields](#scaffolded-fields)
@@ -447,6 +448,21 @@ When replicas are configured, calling the method [`DB::get_conn()`](api:SilverSt
 Note that the `DB::CONN_PRIMARY` constant, which has a value of "primary", is used to specify the primary database used. Prior to CMS 6 when there was no DB replica support, the primary database was referred to as "default". If you have code that uses the string "default" to refer to the primary database, you should update it to use the `DB::CONN_PRIMARY` constant instead.
 
 Note that some [`DataQuery`](api:SilverStripe\ORM\DataQuery) methods such as [`DataQuery::execute()`](api:SilverStripe\ORM\DataQuery::execute()) now work slightly differently as they will use the replica database if the queried `DataObject` has the [`DataObject.must_use_primary_db`](api:SilverStripe\ORM\DataObject->must_use_primary_db) configuration set to `true`. However calling the equivalent [`SQLSelect`](api:SilverStripe\ORM\Queries\SQLSelect) method via a `DataQuery` e.g. `$dataQuery->query()->execute()` will not respect the `DataObject.must_use_primary_db` configuration.
+
+### Performance improvements for site tree rendering {#site-tree-performance}
+
+Performance improvements have been made to the rendering of the site tree used to show all of the pages in the CMS using a combination of more efficient database queries and in-memory caching. The primary focus of this work was to reduce the total number of database requests being made, as this has been found to be a significant source of perceived slowness when Silverstripe CMS is in a distributed hosting setup where the database is on a different physical server from the webserver.
+
+As part of this change a new method [`Hierarchy::getChildrenForTree()`](api:SilverStripe\ORM\Hierarchy\Hierarchy::getChildrenForTree()) has been created which replaces [`Hierarchy::AllChildrenIncludingDeleted()`](api:SilverStripe\ORM\Hierarchy\Hierarchy::AllChildrenIncludingDeleted()) as the default method used to get children to render in the site tree. `Hierarchy::AllChildrenIncludingDeleted()` is now deprecated.
+
+If you want to use `Hierarchy::AllChildrenIncludingDeleted()` to get items to display in the site tree (for example to take advantage of the`augmentAllChildrenIncludingDeleted` extension hook), this can be done with the following config:
+
+```yml
+SilverStripe\CMS\Model\SiteTree:
+  tree_children_method: 'AllChildrenIncludingDeleted'
+```
+
+However it is recommended to use the new method instead and update your code to use the new `updateGetChildrenForTree` extension hook in `Hierarchy::getChildrenForTree()` instead.
 
 ### Run `CanonicalURLMiddleware` in all environments by default {#url-middleware}
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11703

I've added a changelog entry though have not updated the general docs because I do not think the configurability of `default_children_method` should be called out as there's virtually no reason for this to ever be changed

There are no existing docs referencing either `default_children_method` or `AllChildrenIncludingDeleted`