### PR TITLE
DOC Document webauthn getting a CMS 6 compatible release

### DIFF
--- a/en/08_Changelogs/6.0.0.md
+++ b/en/08_Changelogs/6.0.0.md
@@ -104,7 +104,7 @@ Email [community@silverstripe.org](mailto:community@silverstripe.org) if you are
 |[silverstripe/sitewidecontent-report](https://github.com/silverstripe/silverstripe-sitewidecontent-report)|Combined into [silverstripe/reports](https://github.com/silverstripe/silverstripe-reports)|
 |[silverstripe/subsites](https://github.com/silverstripe/silverstripe-subsites)|CMS 6 compatible without commercial support|
 |[silverstripe/versionfeed](https://github.com/silverstripe/silverstripe-versionfeed)|Dropped|
-|[silverstripe/webauthn-authenticator](https://github.com/silverstripe/silverstripe-webauthn-authenticator)|Dropped|
+|[silverstripe/webauthn-authenticator](https://github.com/silverstripe/silverstripe-webauthn-authenticator)|CMS 6 compatible without commercial support|
 |[symbiote/silverstripe-multivaluefield](https://github.com/symbiote/silverstripe-multivaluefield)|Dropped|
 
 The code in `silverstripe/externallinks`, `silverstripe/security-report`, and `silverstripe/sitewidecontent-report` has been copied into `silverstripe/reports` and will be maintained there going forward. The namespaces for classes in those modules has been updated to `SilverStripe\Reports`. Note that any code that related to `silverstripe/subsite` or `silverstripe/contentreview` integration has been removed.


### PR DESCRIPTION
As discussed offline, we have already done the work to make this CMS 6 compatible so may as well release it to provide a smoother upgrade path.

## Issue

- https://github.com/silverstripe/.github/issues/382