### PR TITLE
DOC Document gridfield bugfix that is worth noting

### DIFF
--- a/en/08_Changelogs/6.0.0.md
+++ b/en/08_Changelogs/6.0.0.md
@@ -1018,6 +1018,7 @@ This release includes a number of bug fixes to improve a broad range of areas. C
 
 - [`PaginatedList::count()`](api:SilverStripe\ORM\PaginatedList::count()) used to give the total number of items in the underlying unpaginated list. This wasn't consistent with the number of items in the current page, which is what you get when iterating over the list. The `count()` method now gives you the number of items in the *current page* only. If you want to total number of items in the unpaginated list, use [`PaginatedList::getTotalItems()`](api:SilverStripe\ORM\PaginatedList::getTotalItems()) instead.
 - [`Path::join()`](api:SilverStripe\Core\Path::join()), [`File::find()`](api:SilverStripe\Assets\File::find()), [`File::filterFilename()`](api:SilverStripe\Assets\File::filterFilename()), and [`Folder::find_or_make()`](api:SilverStripe\Assets\Folder::find_or_make()) used to filter out any part of the path that was only `0` (e.g. would return `'a/b'` instead of `'a/0/b'`). This has been fixed. It is possible some paths that were generated with the buggy logic will now become invalid as a result.
+- [`GridFieldAddExistingAutocompleter`](api:SilverStripe\Forms\GridField\GridFieldAddExistingAutocompleter) will no longer search against fields whos configuration opts out of being included in a general search field. See [exclude fields from the general search](/developer_guides/model/scaffolding/#general-search-field) for details about that configuration.
 
 ## API changes
 


### PR DESCRIPTION
This is the sort of thing that someone could _potentially_ be relying on, although it was always incorrect behaviour. Seems sensible to document this change so anyone relying on it can hopefully see it (or if they don't see it, we can point at it if they raise it as a bug).


## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11739