### PR TITLE
DOC Fix "handle nested data" link

### DIFF
--- a/en/02_Developer_Guides/03_Forms/00_Introduction.md
+++ b/en/02_Developer_Guides/03_Forms/00_Introduction.md
@@ -399,7 +399,7 @@ class MyFormPageController extends PageController
 }
 ```
 
-See [how_tos/handle_nested_data](How to: Handle nested form data) for more advanced use cases.
+See [How to: Handle nested form data](how_tos/handle_nested_data) for more advanced use cases.
 
 ## Validation
 


### PR DESCRIPTION
## Description

Fix a wrong link in forms docs.

## Issues

Currently the link is wrongly displayed:

![image](https://github.com/user-attachments/assets/a3a9ddff-5d0d-4f01-b3c7-46899de1ce04)

## Pull request checklist

- [x] The target branch is correct
    - See [branches and commit messages](https://docs.silverstripe.org/en/contributing/documentation#branches-and-commit-messages)
- [x] All commits are relevant to the purpose of the PR (e.g. no TODO comments, unrelated rewording/restructuring, or arbitrary changes)
    - Small amounts of additional changes are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/documentation/)
- [x] The changes follow our [writing style guide](https://docs.silverstripe.org/en/contributing/documentation/#writing-style)
- [x] Code examples follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] CI is green
