### PR TITLE
DOC Update references to renamed API

### DIFF
--- a/en/02_Developer_Guides/00_Model/12_Indexes.md
+++ b/en/02_Developer_Guides/00_Model/12_Indexes.md
@@ -64,7 +64,7 @@ support the following:
 > [!NOTE]
 > Violating a unique index will throw a [`DuplicateEntryException`](api:SilverStripe\ORM\Connect\DuplicateEntryException) exception which you can catch and handle to produce appropriate validation messages.
 >
-> If the violation happens when calling [`DataObject::write()`](api:SilverStripe\ORM\DataObject::write()), the exception will be caught and a [`ValidationException`](api:SilverStripe\ORM\ValidationException) will be thrown instead. The CMS catches any `ValidationException` and displays them as user friendly validation errors in edit forms.
+> If the violation happens when calling [`DataObject::write()`](api:SilverStripe\ORM\DataObject::write()), the exception will be caught and a [`ValidationException`](api:SilverStripe\Core\Validation\ValidationException) will be thrown instead. The CMS catches any `ValidationException` and displays them as user friendly validation errors in edit forms.
 
 ```php
 // app/src/MyTestObject.php

--- a/en/02_Developer_Guides/05_Extending/01_Extensions.md
+++ b/en/02_Developer_Guides/05_Extending/01_Extensions.md
@@ -369,7 +369,7 @@ class MyModel extends DataObject
 
     public function __construct()
     {
-        $this->beforeExtending('populateDefaults', function () {
+        $this->beforeExtending('onAfterPopulateDefaults', function () {
             if (empty($this->MyField)) {
                 $this->MyField = 'Value we want as a default if not specified in $defaults, but set before extensions';
             }

--- a/en/02_Developer_Guides/07_Debugging/01_Error_Handling.md
+++ b/en/02_Developer_Guides/07_Debugging/01_Error_Handling.md
@@ -233,7 +233,7 @@ SilverStripe\Core\Injector\Injector:
     calls:
       pushMyDisplayErrorHandler: [ pushHandler, [ '%$DisplayErrorHandler' ]]
   DisplayErrorHandler:
-    class: SilverStripe\Logging\HTTPOutputHandler
+    class: SilverStripe\Logging\ErrorOutputHandler
     constructor:
       - "notice"
     properties:
@@ -271,7 +271,7 @@ SilverStripe\Core\Injector\Injector:
 
   # Handler for displaying errors in the browser or CLI
   DisplayErrorHandler:
-    class: SilverStripe\Logging\HTTPOutputHandler
+    class: SilverStripe\Logging\ErrorOutputHandler
     constructor:
       - "error"
     properties:

--- a/en/02_Developer_Guides/09_Security/04_Sudo_Mode.md
+++ b/en/02_Developer_Guides/09_Security/04_Sudo_Mode.md
@@ -32,7 +32,7 @@ The following `DataObject` subclasses are protected by sudo mode out of the box:
 
 ### Configuring sudo mode for your models
 
-To add sudo mode for a particular model, including your `DataObject` subclasses, simply set the [`require_sudo_mode`](api:SilverStripe\View\ViewableData->require_sudo_mode) configuration property to `true`, either directly on the class or via yml.
+To add sudo mode for a particular model, including your `DataObject` subclasses, simply set the [`require_sudo_mode`](api:SilverStripe\Model\ModelData->require_sudo_mode) configuration property to `true`, either directly on the class or via yml.
 
 > [!NOTE]
 > This will only add sudo mode to edit forms within the CMS interface. It will have no effect on forms outside of the CMS, such as custom forms in the frontend.

--- a/en/08_Changelogs/6.0.0.md
+++ b/en/08_Changelogs/6.0.0.md
@@ -1072,13 +1072,10 @@ There are a lot of classes which were in the `SilverStripe\ORM` namespace and a 
 |---|---|
 |`SilverStripe\ORM\ArrayLib`|[`SilverStripe\Core\ArrayLib`](api:SilverStripe\Core\ArrayLib)|
 |`SilverStripe\ORM\ArrayList`|[`SilverStripe\Model\List\ArrayList`](api:SilverStripe\Model\List\ArrayList)|
-|`SilverStripe\ORM\Filterable`|[`SilverStripe\Model\List\Filterable`](api:SilverStripe\Model\List\Filterable)|
 |`SilverStripe\ORM\GroupedList`|[`SilverStripe\Model\List\GroupedList`](api:SilverStripe\Model\List\GroupedList)|
-|`SilverStripe\ORM\Limitable`|[`SilverStripe\Model\List\Limitable`](api:SilverStripe\Model\List\Limitable)|
 |`SilverStripe\ORM\ListDecorator`|[`SilverStripe\Model\List\ListDecorator`](api:SilverStripe\Model\List\ListDecorator)|
 |`SilverStripe\ORM\Map`|[`SilverStripe\Model\List\Map`](api:SilverStripe\Model\List\Map)|
 |`SilverStripe\ORM\PaginatedList`|[`SilverStripe\Model\List\PaginatedList`](api:SilverStripe\Model\List\PaginatedList)|
-|`SilverStripe\ORM\Sortable`|[`SilverStripe\Model\List\Sortable`](api:SilverStripe\Model\List\Sortable)|
 |`SilverStripe\ORM\SS_List`|[`SilverStripe\Model\List\SS_List`](api:SilverStripe\Model\List\SS_List)|
 |`SilverStripe\ORM\ValidationException`|[`SilverStripe\Core\Validation\ValidationException`](api:SilverStripe\Core\Validation\ValidationException)|
 |`SilverStripe\ORM\ValidationResult`|[`SilverStripe\Core\Validation\ValidationResult`](api:SilverStripe\Core\Validation\ValidationResult)|

--- a/en/12_Project_Governance/08_Fixed_dependencies.md
+++ b/en/12_Project_Governance/08_Fixed_dependencies.md
@@ -25,7 +25,7 @@ Dependency | Fixed major release line
 
 ## Symfony dependencies
 
-Silverstripe CMS relies on many Symfony packages. Silverstripe CMS 6 tracks the Symfony 7 release. If your Silverstripe CMS project uses Symfony packages, install packages version compatible with Symfony 6 or you may encounter dependency conflicts.
+Silverstripe CMS relies on many Symfony packages. Silverstripe CMS 6 tracks the Symfony 7 release. If your Silverstripe CMS project uses Symfony packages, install packages version compatible with Symfony 7 or you may encounter dependency conflicts.
 
 ## Related information
 


### PR DESCRIPTION
Updates references to renamed API according to the "Many renamed classes" and "Changes to some extension hook names" sections of the changelog.

Also removes the `Limitable`, `Filterable`, and `Sortable` interfaces from the renamed classes list, since those were removed after being renamed.

## Issue

- https://github.com/silverstripe/developer-docs/issues/689