### PR TITLE
DOC Document backporting non-blocking sessions

### DIFF
--- a/en/08_Changelogs/6.1.0.md
+++ b/en/08_Changelogs/6.1.0.md
@@ -120,6 +120,8 @@ See the [save handler documentation](/developer_guides/cookies_and_sessions/sess
 
 Note that if you are using [`silverstripe/hybridsessions`](https://packagist.org/packages/silverstripe/hybridsessions) or [`silverstripe/dynamodb`](https://packagist.org/packages/silverstripe/dynamodb), you can continue to use these with no change, provided you update them to the latest version.
 
+If you want this functionality in your CMS 5 projects, we have created a new [`silverstripe/non-blocking-sessions`](https://github.com/silverstripe/silverstripe-non-blocking-sessions) module that backports the file-based non-blocking session save handler to CMS 5.
+
 ### Password strength feedback
 
 The [`ConfirmedPasswordField`](api:SilverStripe\Forms\ConfirmedPasswordField) now provides real-time feedback on password strength as users type. You'll see this in action on the member edit form, when setting a new password during the "lost password" process, and for any usages of `ConfirmedPasswordField` in your own forms if [`requireStrongPassword`](api:SilverStripe\Forms\ConfirmedPasswordField->requireStrongPassword) is toggled on.


### PR DESCRIPTION
I thought about saying something about how it can help normalise hosting between CMS 5 and CMS 6, but:
1. I couldn't think of a good way to word it that doesn't just add more confusion
2. There's no _concrete_ plans to remove dynamodb as a required module for cloud hosting yet, so I don't want to open that can of worms before we have answers to likely questions

## Issue

- https://github.com/silverstripe/.github/issues/401