### PR TITLE
DOCS fix reference to Extension class

### DIFF
--- a/en/08_Changelogs/6.0.0.md
+++ b/en/08_Changelogs/6.0.0.md
@@ -1965,7 +1965,7 @@ This section contains the full list of APIs that have been changed or removed be
 - Removed deprecated class `SilverStripe\Logging\HTTPOutputHandler` - renamed to ErrorOutputHandler
 - Removed deprecated class `SilverStripe\ORM\ArrayLib` - renamed to [`ArrayLib`](api:SilverStripe\Core\ArrayLib)
 - Removed deprecated class `SilverStripe\ORM\ArrayList` - renamed to [`ArrayList`](api:SilverStripe\Model\List\ArrayList)
-- Removed deprecated class `SilverStripe\ORM\DataExtension` - subclass `SilverStripe\Core\Extension\Extension` instead
+- Removed deprecated class `SilverStripe\ORM\DataExtension` - subclass `SilverStripe\Core\Extension` instead
 - Removed deprecated class `SilverStripe\ORM\DatabaseAdmin` - replaced with [`DbBuild`](api:SilverStripe\Dev\Command\DbBuild)
 - Removed deprecated class `SilverStripe\ORM\GroupedList` - renamed to [`GroupedList`](api:SilverStripe\Model\List\GroupedList)
 - Removed deprecated class `SilverStripe\ORM\ListDecorator` - renamed to [`ListDecorator`](api:SilverStripe\Model\List\ListDecorator)


### PR DESCRIPTION
SilverStripe\Core\Extension\Extension is an invalid FQCN

## Description
Reference to Extension class is invalid

## Issues
- https://github.com/silverstripe/developer-docs/issues/813

## Pull request checklist
- [x] The target branch is correct
    - See [branches and commit messages](https://docs.silverstripe.org/en/contributing/documentation#branches-and-commit-messages)
- [x] All commits are relevant to the purpose of the PR (e.g. no TODO comments, unrelated rewording/restructuring, or arbitrary changes)
    - Small amounts of additional changes are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/documentation/)
- [x] The changes follow our [writing style guide](https://docs.silverstripe.org/en/contributing/documentation/#writing-style)
- [x] Code examples follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] CI is green
