### PR TITLE
DOC Update changelog for font-icon changes

### DIFF
--- a/en/08_Changelogs/6.2.0.md
+++ b/en/08_Changelogs/6.2.0.md
@@ -38,11 +38,11 @@ When the help menu is opened or closed, focus is moved to the relevant button so
 
 #### Changes to usage of `font-icon-*` CSS classes
 
-The `font-icon-*` CSS classes used to add icons through the CMS use a font to render normal characters as icons.
+The `font-icon-*` CSS classes are used to add icons through the CMS use a font to render normal characters as icons.
 
 This is very useful for sighted users, but represents a problem for screen reader users, since screen readers want to read the icons like normal characters. For example, the `font-icon-search` icon uses the character "s", so screen readers will read out "s" whenever they encounter that icon.
 
-In many places in the CMS markup we have added `aria-hidden="true"` to elements using `font-icon-*` CSS classes. Often this has required removing the CSS class from the element it was on, and adding it instead to a child `<span>` element. We have also changed some `<i>` elements into `<span>` elements.
+In many places in the CMS markup we have added `aria-hidden="true"` to elements using `font-icon-*` CSS classes. Often this has required removing the CSS class from the element it was on, and adding it instead to a child `<span>` element. We have also changed some `<i>` elements into `<span>` elements for consistency.
 
 If you were relying on an element having a CSS class that starts with `font-icon-` in the CMS, please review your code, as the CSS class you're looking for may be on a child element now.
 
@@ -65,6 +65,7 @@ It's best practice to avoid using deprecated code where possible, but sometimes 
 - The [`Relation::getIDList()`](api:SilverStripe\ORM\Relation::getIDList()) method has been deprecated. Use `$list->sort(null)->column('ID')` instead.
 - The [`EagerLoadedList::getIDList()`](api:SilverStripe\ORM\EagerLoadedList::getIDList()) method has been deprecated. Use `$list->column('ID')` instead.
 - The [`UnsavedRelationList::getIDList()`](api:SilverStripe\ORM\UnsavedRelationList::getIDList()) method has been deprecated. Use `$list->column('ID')` instead.
+- The `IconHOC` react component has been deprecated and will be removed in a future major release without a replacement. The `Button` component's `icon` prop will still remain.
 
 ## Bug fixes
 


### PR DESCRIPTION
A few minor tweaks to wording, plus a note about the deprecated `IconHOC` react component.

## Issue

- https://github.com/silverstripe/silverstripe-admin/issues/1957