### PR TITLE
DOC Document that you cannot rely on env vars set in _config.php in yaml

### DIFF
--- a/en/00_Getting_Started/03_Environment_Management.md
+++ b/en/00_Getting_Started/03_Environment_Management.md
@@ -67,6 +67,8 @@ Environment::setEnv('API_KEY', 'AABBCCDDEEFF012345');
 ```
 
 > [!WARNING]
+> Environment variables set using `Environment::setEnv()` in `_config.php` files are not available to YAML configuration (including conditions like `envvarset` in `Only`/`Except`). This is because YAML config is loaded during the manifest boot phase, which occurs before `_config.php` files are executed. To use environment variables in YAML config, define them in your `.env` file or as actual system environment variables.
+>
 > `Environment::getEnv()` will return `false` whether the variable was explicitly set as `false` or simply wasn't set at all. You can use [`Environment::hasEnv()`](api:SilverStripe\Core\Environment::hasEnv()) to check whether an environment variable was set or not.
 
 ### Using environment variables in config


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/8911

This isn't really a bug as yaml is processed before _config.php. I've simply documented that you cannot define things in _config.php and then use them in yaml.