### PR TITLE
DOC module_priority moved to ModuleManifest from i18n

### DIFF
--- a/en/02_Developer_Guides/13_i18n/index.md
+++ b/en/02_Developer_Guides/13_i18n/index.md
@@ -333,14 +333,12 @@ To create a custom module order, you need to specify a config fragment that inse
 Name: customi18n
 Before: '#defaulti18n'
 ---
-SilverStripe\i18n\i18n:
+SilverStripe\Core\Manifest\ModuleManifest:
   module_priority:
     - module1
     - module2
     - module3
 ```
-
-The config option being set is `i18n.module_priority`, and it is a list of module names.
 
 There are a few special cases:
 


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/documentation/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe the changes you're making, and the reason for making them.
  For visual fixes, please include tested browsers and screenshots.
-->

Fixes https://github.com/silverstripe/developer-docs/issues/841

Removed _"The config option being set is i18n.module_priority, and it is a list of module names."_ as well, this text seems unnecessary (?)

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [branches and commit messages](https://docs.silverstripe.org/en/contributing/documentation#branches-and-commit-messages)
- [ ] All commits are relevant to the purpose of the PR (e.g. no TODO comments, unrelated rewording/restructuring, or arbitrary changes)
    - Small amounts of additional changes are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/documentation/)
- [ ] The changes follow our [writing style guide](https://docs.silverstripe.org/en/contributing/documentation/#writing-style)
- [ ] Code examples follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] CI is green
