### PR TITLE
DOC Remove hardcoded table of contents

### DIFF
--- a/en/03_Upgrading/07_Upgrading_Fluent.md
+++ b/en/03_Upgrading/07_Upgrading_Fluent.md
@@ -9,18 +9,6 @@ Silverstripe only commercially supports version 4.x of [tractorcow/silverstripe-
 
 This documents some of the breaking and functional changes across these three major release lines of the fluent module, as well as some key things to look out for and general guidelines on how to adapt your code to be compatible with the latest version.
 
-- [Breaking API changes](#breaking-api-changes)
-- [Localisation settings](#localisation-settings)
-  - [Locale fallback](#locale-fallback)
-  - [User permissions](#user-permissions)
-  - [Enhanced CMS UI](#enhanced-cms-ui)
-- [Localised versioned history](#localised-version-history)
-  - [Standard Versioned methods](#standard-versioned-methods)
-- [Localised relations](#localised-relations)
-- [Quality of life changes](#quality-of-life-changes)
-- [Unit tests](#unit-tests)
-- [Further reading](#further-reading)
-
 ## Breaking API changes
 
 Fluent v5 and v6 both introduced some breaking API changes.

--- a/en/04_Changelogs/4.10.0.md
+++ b/en/04_Changelogs/4.10.0.md
@@ -4,14 +4,6 @@
 
 A full list of module versions included in CMS Recipe 4.10.0 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/recipes/) for more information.
 
-- [Regression test and Security audit](#audit)
-- [PHPUnit 9.5 and PHP 8.0 official support](#php8)
-- [Dropping support for legacy technologies](#eol)
-  - [Dropping support for PHP 7.1 and PHP 7.2](#phpeol)
-  - [Dropping support for Microsoft Internet Explorer](#ie11)
-- [Features and enhancements](#features-and-enhancements)
-- [Bugfixes](#bugfixes)
-
 <details>
 <summary>Included module versions</summary>
 

--- a/en/04_Changelogs/4.11.0.md
+++ b/en/04_Changelogs/4.11.0.md
@@ -6,21 +6,6 @@ title: 4.11.0
 
 ## Overview
 
-- [Security considerations](#security-considerations)
-- [Regression test and Security audit](#audit)
-- [Adding support for PHP 8.1](#php81)
-- [Dropping support for PHP 7.3](#phpeol)
-- [GraphQL v4 major release](#graphqlv4)
-- [Features and enhancements](#features-and-enhancements)
-  - [Upload and use WebP images in the CMS](#webp)
-  - [Preview any `DataObject` in any admin section](#cms-preview)
-  - [Meta generator tag now shows framework version number](#meta-tag-version)
-  - [Allow-plugins configuration option in Composer versions 2.2.0 and up](#composer)
-  - [Users will recieve an email if their password is changed](#change-password-email)
-  - [Other features](#other-features)
-- [Dependency and internal API changes](#dependency-internal-api-changes)
-- [Bugfixes](#bugfixes)
-
 <details>
 <summary>Included module versions</summary>
 

--- a/en/04_Changelogs/4.11.1.md
+++ b/en/04_Changelogs/4.11.1.md
@@ -12,23 +12,6 @@ The primary purposes of this releases is to patch 9 vulnerabilities against Silv
 - 7 medium impact *cross site scripting* (XSS) vulnerabilities with CVSS scores ranging from 4.2 to 5.4
 - 1 low impact XSS vulnerability with a CVSS score of 3.7.
 
-Contents
-
-- [Upgrade considerations](#upgrade-considerations)
-- [Security considerations](#security-considerations)
-  - [CVE-2022-38148 Blind SQL Injection in gridfield state from URL](#cve-2022-38148)
-  - [CVE-2022-38146 URL XSS vulnerability due to outdated jQuery in CMS](#cve-2022-38146)
-  - [CVE-2022-38462 Reflected XSS in backURL get variable](#cve-2022-38462)
-  - [CVE-2022-38724 XSS in shortcodes](#cve-2022-38724)
-  - [CVE-2022-38145 Stored XSS in Compare Mode feature of history view](#cve-2022-38145)
-  - [CVE-2022-37430 Stored XSS using uppercase characters in HTMLEditor](#cve-2022-37430)
-  - [CVE-2022-37429 Stored XSS using HTMLEditor](#cve-2022-37429)
-  - [CVE-2022-37421 Stored XSS when creating a page with "Custom Meta Tags"](#cve-2022-37421)
-  - [CVE-2022-38147 Stored XSS by uploading ".gpx" file](#cve-2022-38147)
-- [Future jQuery update](#jquery)
-- [Regression test and Security audit](#audit)
-- [Bugfixes](#bugfixes)
-
 <details>
 <summary>Included module versions</summary>
 

--- a/en/04_Changelogs/4.12.0.md
+++ b/en/04_Changelogs/4.12.0.md
@@ -4,21 +4,6 @@
 
 A full list of module versions included in CMS Recipe 4.12.0-rc1 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/).
 
-- [Security considerations](#security-considerations)
-- [Regression test and Security audit](#audit)
-- [Features and enhancements](#features-and-enhancements)
-  - [jQuery updated from 1.7 to 3.6](#jquery)
-  - [Search multiple `searchable_fields` by default](#general-search-field)
-  - [Samesite attribute on cookies](#cookies-samesite)
-  - [`canView` permission required to access a submitted file in `UserForm`](#access-submitted-files)
-  - [New convenience methods for `ModelAdmin`](#modeladmin-convenience)
-  - [Easily link to `DataObject` with `CMSEditLinkExtension`](#link-data-extension)
-  - [Assets API formalisation and deprecations](#assets-api-formalisation-deprecation)
-  - [Other features](#other-features)
-- [Deprecating APIs ahead of Silverstripe CMS 5](#deprecation-cms5)
-  - [Showing deprecations warnings](#showing-deprecations)
-- [Bugfixes](#bugfixes)
-
 <details>
 <summary>Included module versions</summary>
 

--- a/en/04_Changelogs/4.13.0.md
+++ b/en/04_Changelogs/4.13.0.md
@@ -4,15 +4,6 @@
 
 A full list of module versions included in CMS Recipe 4.13.0 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/recipes/).
 
-- [Security considerations](#security-considerations)
-- [API changes](#api-changes)
-  - [Deprecated API (by module, alphabetically)](#api-deprecated)
-- [Features and enhancements](#features-and-enhancements)
-  - [GraphQL v4 additional fallback](#graphql-v4-additional-fallback)
-  - [Other features and enhancements](#other-features-and-enhancements)
-- [Bug fixes](#bug-fixes)
-- [Change Log](#change-log)
-
 <details>
 <summary>Included module versions</summary>
 

--- a/en/04_Changelogs/4.6.0.md
+++ b/en/04_Changelogs/4.6.0.md
@@ -1,15 +1,5 @@
 # 4.6.0
 
-## Overview {#overview}
-
-- [MySQL tables are auto-converted from MyISAM to InnoDB](#myisam)
-- [Editing files directly in the insert-media modal](#in-modal-editing)
-- [MIME Type validation now a core module](#mime-validator)
-- [Solr no longer indexes draft/restricted content](#solr-updates)
-- [Simplify customisation of ModelAdmin](#modeladmin-customisation)
-- [Login forms module ships with installer](#loginforms)
-- [PHP 7.4 compatibility](#php7-4)
-
 ## Security patches
 
 This release contains security patches. Some of those patches might require some

--- a/en/04_Changelogs/4.7.0.md
+++ b/en/04_Changelogs/4.7.0.md
@@ -2,15 +2,6 @@
 
 ## Overview
 
-- [Updated file usage table](#updated-file-usage-table)
-- [Support for PHP 8](#support-for-php-8)
-- [Support for Symfony 4 Components](#support-for-symfony-4-components)
-- [Default MySQL collation updated](#default-mysql-collation-updated)
-- [MySQL connection mode configurable](#mysql-connection-mode-now-configurable)
-- [Flysystem dependency shifted](#flysystem-dependency-shifted)
-- [Improved Toast notifications](#improved-toast-notifications)
-- [DataObject constructor support for hydration](#dataobject-constructor-support-for-hydration)
-
 A full list of module versions included in Recipe 4.7.0 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/recipes) for more information.
 
 <details>

--- a/en/04_Changelogs/4.8.0.md
+++ b/en/04_Changelogs/4.8.0.md
@@ -2,14 +2,6 @@
 
 ## Overview
 
-- [Security considerations](#security-considerations)
-- [Features and enhancements](#features-and-enhancements)
-  - [Support for silverstripe/graphql v4](#graphql-v4)
-  - [GraphQL 3 code moved to _legacy folder](#graphql-v3-legacy)
-  - [Improvements to the login form template and signed in period](#default-period)
-  - [Other new features](#other-features)
-- [Bugfixes](#bugfixes)
-
 A full list of module versions included in CMS Recipe 4.8.0 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/).
 
 <details>

--- a/en/04_Changelogs/4.9.0.md
+++ b/en/04_Changelogs/4.9.0.md
@@ -95,18 +95,6 @@ Upgrading to Silverstripe CMS Recipe 4.9.0 is recommended for all sites. This up
 
 In addition to the below, have a read of the [CMS 4.9 release announcement](https://www.silverstripe.org/blog/cms-4-9-is-here/).
 
-- [Security considerations](#security-considerations)
-- [Security audit and regression test](#audit)
-- [For development teams of Common Web Platform projects](#cwp-end)
-- [Dropping support for Internet Explorer 11](#ie11eol)
-- [Features and enhancements](#features-and-enhancements)
-  - [Changes to our release process](#release-process)
-  - [Image lazy loading](#image-lazy-loading)
-  - [Manage your CMS sessions across devices](#session-manager)
-  - [Upgrade to Swiftmailer version 6](#swiftmailer)
-  - [Other new features](#other-new-features)
-- [Bugfixes](#bugfixes)
-
 ## Security considerations {#security-considerations}
 
 This release includes security fixes. Review the individual vulnerability disclosure for more detailed descriptions of each security fix. We highly encourage upgrading your project to include the latest security patches.

--- a/en/04_Changelogs/beta/4.10.0-beta1.md
+++ b/en/04_Changelogs/beta/4.10.0-beta1.md
@@ -4,12 +4,6 @@ The 4.10.0-beta1 release is not stable and likely contains bugs. The purpose of 
 
 ## Overview
 
-- [Stable module forcing installation of unstable framework](#unstable-framework)
-- [PHPUnit 9.5 and PHP 8.0 official support](#php8)
-- [Dropping support for PHP 7.1 and PHP 7.2](#phpeol)
-- [Features and enhancements](#features-and-enhancements)
-- [Bugfixes](#bugfixes)
-
 <details>
 <summary>Included module versions</summary>
 

--- a/en/04_Changelogs/beta/4.11.0-beta1.md
+++ b/en/04_Changelogs/beta/4.11.0-beta1.md
@@ -4,17 +4,6 @@ A full list of module versions included in CMS Recipe 4.11.0-beta1 is provided b
 
 ## Overview
 
-- [Upgrading to GraphQL v4](#graphqlv4)
-- [Adding support for PHP 8.1](#php81)
-- [Dropping support for PHP 7.3](#php73)
-- [Features and enhancements](#features-and-enhancements)
-  - [Upload and use WebP images in the CMS](#webp)
-  - [Preview any DataObject in any admin section](#cms-preview)
-  - [Allow-plugins configuration option in Composer versions 2.2.0 and up](#composer)
-  - [Other features](#other-features)
-- [Bugfixes](#bugfixes)
-- [Dependency and internal API changes](#dependency-internal-api-changes)
-
 <details>
 <summary>Included module versions</summary>
 

--- a/en/04_Changelogs/beta/4.12.0-beta1.md
+++ b/en/04_Changelogs/beta/4.12.0-beta1.md
@@ -4,17 +4,6 @@
 
 A full list of module versions included in CMS Recipe 4.12.0-beta1 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/).
 
-- [Features and enhancements](#features-and-enhancements)
-  - [jQuery updated from 1.7 to 3.6](#jquery)
-  - [Search multiple `searchable_fields` by default](#general-search-field)
-  - [Samesite attribute on cookies](#cookies-samesite)
-  - [The canView permission required to access a submitted file in UserForm](#access-submitted-files)
-  - [New convenience methods for `ModelAdmin`](#modeladmin-convenience)
-  - [Assets API formalisation and deprecations](#assets-api-formalisation-deprecation)
-  - [Other features](#other-features)
-- [Bugfixes](#bugfixes)
-  - [Deprecation class](#deprecation-class)
-
 <details>
 <summary>Included module versions</summary>
 

--- a/en/04_Changelogs/beta/4.13.0-beta1.md
+++ b/en/04_Changelogs/beta/4.13.0-beta1.md
@@ -4,12 +4,6 @@
 
 A full list of module versions included in CMS Recipe 4.13.0-beta1 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/).
 
-- [API changes](#api-changes)
-  - [Deprecated API (by module, alphabetically)](#api-deprecated)
-- [Features and enhancements](#features-and-enhancements)
-- [Bug fixes](#bug-fixes)
-- [Change Log](#change-log)
-
 <details>
 <summary>Included module versions</summary>
 

--- a/en/04_Changelogs/beta/4.6.0-beta1.md
+++ b/en/04_Changelogs/beta/4.6.0-beta1.md
@@ -1,11 +1,5 @@
 # 4.6.0-beta1
 
-## Overview {#overview}
-
-- [MySQL tables are auto-converted from MyISAM to InnoDB](#myisam)
-- [Editing files directly in the insert-media modal](#in-modal-editing)
-- [MIME Type validation now a core module](#mime-validator)
-
 ## MySQL tables are auto-converted from MyISAM to InnoDB {#myisam}
 
 Beginning with [4.4.0](https://docs.silverstripe.org/en/4/changelogs/4.4.0/),

--- a/en/04_Changelogs/beta/4.7.0-beta1.md
+++ b/en/04_Changelogs/beta/4.7.0-beta1.md
@@ -1,16 +1,5 @@
 # 4.7.0-beta1
 
-## Overview
-
-- [Updated file usage table](#updated-file-usage-table)
-- [Experimental support for PHP 8](#experimental-support-for-php-8)
-- [Support for Symfony 4 Components](#support-for-symfony-4-components)
-- [Default MySQL collation updated](#default-mysql-collation-updated)
-- [MySQL connection mode configurable](#mysql-connection-mode-now-configurable)
-- [Flysystem dependency shifted](#flysystem-dependency-shifted)
-- [Improved Toast notifications](#improved-toast-notifications)
-- [DataObject constructor support for hydration](#dataobject-constructor-support-for-hydration)
-
 ## New features
 
 ### Updated file usage table

--- a/en/04_Changelogs/beta/4.8.0-beta1.md
+++ b/en/04_Changelogs/beta/4.8.0-beta1.md
@@ -2,11 +2,6 @@
 
 ## Overview
 
-- [Support for silverstripe/graphql v4](#graphql-v4)
-- [Improvements to the login form template and signed in period](#default-period)
-- [Other new features](#features)
-- [Bugfixes](#bugfixes)
-
 A full list of module versions included in CMS Recipe 4.8.0-beta1 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/).
 
 <details>

--- a/en/04_Changelogs/beta/4.9.0-beta1.md
+++ b/en/04_Changelogs/beta/4.9.0-beta1.md
@@ -10,15 +10,6 @@ More information and guidance on how to manage your project composer.json file w
 
 ## Overview
 
-- [Features and enhancements](#features-and-enhancements)
-  - [Changes to our release process](#release-process)
-  - [Image lazy loading](#image-lazy-loading)
-  - [Manage your CMS sessions across devices](#session-manager)
-  - [Default mail transport upgraded to sendmail](#sendmail)
-  - [Support for silverstripe/graphql v4](#graphqlv4)
-  - [Other new features](#other-new-features)
-- [Bugfixes](#bugfixes)
-
 <details>
 <summary>Core module versions</summary>
 

--- a/en/04_Changelogs/rc/4.10.0-rc1.md
+++ b/en/04_Changelogs/rc/4.10.0-rc1.md
@@ -6,11 +6,6 @@ This version of Silverstripe CMS is a **release candidate** for an upcoming stab
 
 A full list of module versions included in CMS Recipe 4.10.0-rc1 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/).
 
-- [PHPUnit 9.5 and PHP 8.0 official support](#php8)
-- [Dropping support for PHP 7.1 and PHP 7.2](#phpeol)
-- [Features and enhancements](#features-and-enhancements)
-- [Bugfixes](#bugfixes)
-
 <details>
 <summary>Included module versions</summary>
 

--- a/en/04_Changelogs/rc/4.11.0-rc1.md
+++ b/en/04_Changelogs/rc/4.11.0-rc1.md
@@ -6,19 +6,6 @@ This version of Silverstripe CMS is a **release candidate** for an upcoming stab
 
 A full list of module versions included in CMS Recipe 4.11.0-rc1 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/).
 
-- [Regression test and Security audit](#audit)
-- [Upgrading to GraphQL v4](#graphqlv4)
-- [Adding support for PHP 8.1](#php81)
-- [Dropping support for PHP 7.3](#phpeol)
-- [Features and enhancements](#features-and-enhancements)
-  - [Upload and use WebP images in the CMS](#webp)
-  - [Preview any DataObject in any admin section](#cms-preview)
-  - [Allow-plugins configuration option in Composer versions 2.2.0 and up](#composer)
-  - [Users will recieve an email if their password is changed](#change-password-email)
-  - [Other features](#other-features)
-- [Bugfixes](#bugfixes)
-- [Dependency and internal API changes](#dependency-internal-api-changes)
-
 <details>
 <summary>Included module versions</summary>
 

--- a/en/04_Changelogs/rc/4.12.0-rc1.md
+++ b/en/04_Changelogs/rc/4.12.0-rc1.md
@@ -4,18 +4,6 @@
 
 A full list of module versions included in CMS Recipe 4.12.0-rc1 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/).
 
-- [Release Candidate](#release-candidate)
-- [Features and enhancements](#features-and-enhancements)
-  - [jQuery updated from 1.7 to 3.6](#jquery)
-  - [Search multiple `searchable_fields` by default](#general-search-field)
-  - [Samesite attribute on cookies](#cookies-samesite)
-  - [The canView permission required to access a submitted file in UserForm](#access-submitted-files)
-  - [New convenience methods for `ModelAdmin`](#modeladmin-convenience)
-  - [Assets API formalisation and deprecations](#assets-api-formalisation-deprecation)
-  - [Other features](#other-features)
-- [Bugfixes](#bugfixes)
-  - [Deprecation class](#deprecation-class)
-
 <details>
 <summary>Included module versions</summary>
 

--- a/en/04_Changelogs/rc/4.13.0-rc1.md
+++ b/en/04_Changelogs/rc/4.13.0-rc1.md
@@ -4,14 +4,6 @@
 
 A full list of module versions included in CMS Recipe 4.13.0-rc1 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/).
 
-- [API changes](#api-changes)
-  - [Deprecated API (by module, alphabetically)](#api-deprecated)
-- [Features and enhancements](#features-and-enhancements)
-  - [GraphQL v4 additional fallback](#graphql-v4-additional-fallback)
-  - [Other features and enhancements](#other-features-and-enhancements)
-- [Bug fixes](#bug-fixes)
-- [Change Log](#change-log)
-
 <details>
 <summary>Included module versions</summary>
 

--- a/en/04_Changelogs/rc/4.6.0-rc1.md
+++ b/en/04_Changelogs/rc/4.6.0-rc1.md
@@ -1,11 +1,5 @@
 # 4.6.0-rc1
 
-## Overview {#overview}
-
-- [MySQL tables are auto-converted from MyISAM to InnoDB](#myisam)
-- [Editing files directly in the insert-media modal](#in-modal-editing)
-- [MIME Type validation now a core module](#mime-validator)
-
 ## Release candidate
 
 This version of Silverstripe CMS is a **release candidate** for an upcoming stable version, and should not be applied to production websites. We encourage developers to test this version in development / testing environments and report any issues they encounter via GitHub.

--- a/en/04_Changelogs/rc/4.7.0-rc1.md
+++ b/en/04_Changelogs/rc/4.7.0-rc1.md
@@ -4,17 +4,6 @@
 
 This version of Silverstripe CMS is a **release candidate** for an upcoming stable version, and should not be applied to production websites. We encourage developers to test this version in development / testing environments and [report any issues they encounter via GitHub](/contributing/issues_and_bugs/).
 
-## Overview
-
-- [Updated file usage table](#updated-file-usage-table)
-- [Experimental support for PHP 8](#experimental-support-for-php-8)
-- [Support for Symfony 4 Components](#support-for-symfony-4-components)
-- [Default MySQL collation updated](#default-mysql-collation-updated)
-- [MySQL connection mode configurable](#mysql-connection-mode-now-configurable)
-- [Flysystem dependency shifted](#flysystem-dependency-shifted)
-- [Improved Toast notifications](#improved-toast-notifications)
-- [DataObject constructor support for hydration](#dataobject-constructor-support-for-hydration)
-
 ## New features
 
 ### Updated file usage table

--- a/en/04_Changelogs/rc/4.8.0-rc1.md
+++ b/en/04_Changelogs/rc/4.8.0-rc1.md
@@ -2,11 +2,6 @@
 
 ## Overview
 
-- [Support for silverstripe/graphql v4](#graphql-v4)
-- [Improvements to the login form template and signed in period](#default-period)
-- [Other new features](#features)
-- [Bugfixes](#bugfixes)
-
 A full list of module versions included in CMS Recipe 4.8.0-rc1 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/).
 
 <details>

--- a/en/04_Changelogs/rc/4.9.0-rc1.md
+++ b/en/04_Changelogs/rc/4.9.0-rc1.md
@@ -4,16 +4,6 @@
 
 A full list of module versions included in CMS Recipe 4.9.0-rc1 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/).
 
-- [For development teams of Common Web Platform projects](#cwp-end)
-- [Dropping support for Internet Explorer 11](#ie11eol)
-- [Features and enhancements](#features-and-enhancements)
-  - [Image lazy loading](#image-lazy-loading)
-  - [Manage your CMS sessions across devices](#session-manager)
-  - [Default mail transport upgraded to sendmail](#sendmail)
-  - [Support for silverstripe/graphql v4](#graphqlv4)
-  - [Other new features](#other-new-features)
-- [Bugfixes](#bugfixes)
-
 <details>
 <summary>Core module versions</summary>
 


### PR DESCRIPTION
The new docs site will be generating a table of contents that is more accurate and works on all pages, so we need to remove the redundant hardcoded ToC.

I thought I remembered the graphql docs having them too, but it turns out those are children lists, which won't be replaced with the automated ToC.

Note I haven't bothered wrapping the commits list for these nor for CMS 3, since they're so old now I doubt they'll be looked at very much.

## Issue

- https://github.com/silverstripe/doc.silverstripe.org/issues/347