### PR TITLE
DOC Remove hardcoded table of contents from 6.2 changelog

### DIFF
--- a/en/08_Changelogs/6.2.0.md
+++ b/en/08_Changelogs/6.2.0.md
@@ -6,17 +6,18 @@ title: 6.2.0 (unreleased)
 
 ## Overview
 
-- [Features and enhancements](#features-and-enhancements)
-  - [Accessibility improvements](#accessibility-improvements)
-  - [Unsaved changes indicator](#unsaved-changes-indicator)
-  - [PHP 8.5 support](#php-8-5-support)
-  - [Move elemental blocks](#move-elemental-blocks)
-  - [Pass arbitrary attributes with requirements API](#requirements-attributes)
-  - [Filter archived records](#filter-archived-records)
-  - [Filter campaigns](#filter-campaigns)
-  - [Other new features and enhancements](#other-new)
-- [API changes](#api-changes)
-- [Bug fixes](#bug-fixes)
+<details>
+
+<summary>Included module versions</summary>
+
+<!-- markdownlint-disable enhanced-proper-names -->
+
+| Module | Version |
+| ------ | ------- |
+
+<!-- markdownlint-enable enhanced-proper-names -->
+
+</details>
 
 ## Features and enhancements
 


### PR DESCRIPTION
The new docs site will be generating a table of contents that is more accurate and works on all pages, so we need to remove the redundant hardcoded ToC.


## Issue

- https://github.com/silverstripe/doc.silverstripe.org/issues/347