### PR TITLE
Deprecate base tag and update changelog for 6.2.0

### DIFF
--- a/en/08_Changelogs/6.2.0.md
+++ b/en/08_Changelogs/6.2.0.md
@@ -205,6 +205,23 @@ The "Campaigns" admin section which is added through [`silverstripe/campaign-adm
 
 You can filter by the name and description of the campaign, its status, and the publish date. This is all powered by [`searchable_fields`](/developer_guides/model/scaffolding/#searchable-fields) configuration for the [`ChangeSet`](api:SilverStripe\Versioned\ChangeSet) class, so you can customise the search fields by changing that configuration if you want to.
 
+### Good bye, base tag
+
+The `<base>` tag that Silverstripe CMS has long since used can cause issues, for example with server configuration, reverse proxies, and fragment links. It is not actually necessary for Silverstripe CMS to function. In this release, we have fixed the remaining bugs in the admin UI that necessitated the base tag, and have deprecated it.
+
+The admin UI still includes the base tag by default, and will do so until a future major release. You can remove that with the following configuration:
+
+```yml
+SilverStripe\View\SSViewer:
+  enable_base_tag: false
+  rewrite_hash_links: false
+```
+
+We encourage everyone to remove the `<% base_tag %>` directive from their templates, and to make this configuration change.
+
+> [!NOTE]
+> When [`SSViewer.enable_base_tag`](api:SilverStripe\View\SSViewer->enable_base_tag) is set to false, the [`AdminRootController::admin_url()`](api:SilverStripe\Admin\AdminRootController::admin_url()) method now returns URLs of the form `/admin/pages` (or `/mysite/admin/pages` if you site runs in a subfolder) instead of `admin/pages`. If you call this method directly, it might pay to make sure your logic can handle this scenario (e.g. if doing string-matching on the value).
+
 ### Other new features and enhancements {#other-new}
 
 - A new [`ChildFieldManager`](api:SilverStripe\Forms\ChildFieldManager) interface has been added to allow a parent form field to strictly control its children, but still allow setting/getting values for those fields let them handle AJAX requests. See [`ChildFieldManager` docs](/developer_guides/forms/field_types/childfieldmanager/) for more details.
@@ -249,6 +266,7 @@ It's best practice to avoid using deprecated code where possible, but sometimes 
 - The [`UnsavedRelationList::getIDList()`](api:SilverStripe\ORM\UnsavedRelationList::getIDList()) method has been deprecated. Use `$list->column('ID')` instead.
 - The `IconHOC` react component has been deprecated and will be removed in a future major release without a replacement. The `Button` component's `icon` prop will still remain.
 - The [`FieldList::dataFields()`](api:SilverStripe\Forms\FieldList::dataFields()) method has been deprecated. Use[`FieldList::getDataFields()`](api:SilverStripe\Forms\FieldList::getDataFields()) instead.
+- Use of `<% base_tag %>` in templates has been deprecated, as the base tag is not necessary for Silverstripe CMS to work.
 
 ## Bug fixes
 


### PR DESCRIPTION
Deprecate the base tag in Silverstripe and provide configuration instructions for removal. Update documentation regarding changes to admin URL structure and other enhancements.  See https://github.com/silverstripe/silverstripe-framework/pull/11964

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11961