### PR TITLE
DOC Fix typo in CMS 6.2.0 changelog

### DIFF
--- a/en/08_Changelogs/6.2.0.md
+++ b/en/08_Changelogs/6.2.0.md
@@ -37,7 +37,7 @@ Keyboard navigation has been added for the site tree within the CMS, which now u
 
 #### Keyboard navigation for "Files" admin section
 
-Keyboard navigation has been improved for the in the "Files" admin section. The files gallery and table views both now use a [roving tabindex](#roving-tabindex).
+Keyboard navigation has been improved in the "Files" admin section. The files gallery and table views both now use a [roving tabindex](#roving-tabindex).
 
 Users can now navigate between files and folders in the gallery view using arrow keys. The "End" and "Home" keys move focus to the first and last items in the current row, and holding control with those keys moves focus to the first and last items in the gallery respectively.
 

--- a/en/08_Changelogs/beta/6.2.0-beta1.md
+++ b/en/08_Changelogs/beta/6.2.0-beta1.md
@@ -82,7 +82,7 @@ Keyboard navigation has been added for the site tree within the CMS, which now u
 
 #### Keyboard navigation for "Files" admin section
 
-Keyboard navigation has been improved for the in the "Files" admin section. The files gallery and table views both now use a [roving tabindex](#roving-tabindex).
+Keyboard navigation has been improved in the "Files" admin section. The files gallery and table views both now use a [roving tabindex](#roving-tabindex).
 
 Users can now navigate between files and folders in the gallery view using arrow keys. The "End" and "Home" keys move focus to the first and last items in the current row, and holding control with those keys moves focus to the first and last items in the gallery respectively.
 


### PR DESCRIPTION


## Issue

- https://github.com/silverstripe/developer-docs/issues/883