### PR TITLE
DOC Fix note about site tree keyboard use

### DIFF
--- a/en/08_Changelogs/6.2.0.md
+++ b/en/08_Changelogs/6.2.0.md
@@ -31,7 +31,7 @@ We've implemented roving tabindex for some UI regions within the CMS. These area
 
 ### Keyboard navigation for the site tree
 
-Keyboard navigation has been added for the site tree within the CMS, which now uses a [roving tabindex](#roving-tabindex). Users can now navigate, expand, and collapse tree nodes using arrow keys or the tab key. The "End" and "Home" keys move focus to the top and bottom page in the current nesting level, and the space bar expands and collapses nodes with children.
+Keyboard navigation has been added for the site tree within the CMS, which now uses a [roving tabindex](#roving-tabindex). Users can now navigate, expand, and collapse tree nodes using arrow keys or the tab key. The "End" and "Home" keys move focus to the top and bottom page in the current nesting level. The "Enter" key opens the edit form for the page, and (when "batch actions" mode has been activated) the space bar selects the page.
 
 ### Keyboard navigation for "Files" admin section
 

--- a/en/08_Changelogs/beta/6.2.0-beta1.md
+++ b/en/08_Changelogs/beta/6.2.0-beta1.md
@@ -76,7 +76,7 @@ We've implemented roving tabindex for some UI regions within the CMS. These area
 
 ### Keyboard navigation for the site tree
 
-Keyboard navigation has been added for the site tree within the CMS, which now uses a [roving tabindex](#roving-tabindex). Users can now navigate, expand, and collapse tree nodes using arrow keys or the tab key. The "End" and "Home" keys move focus to the top and bottom page in the current nesting level, and the space bar expands and collapses nodes with children.
+Keyboard navigation has been added for the site tree within the CMS, which now uses a [roving tabindex](#roving-tabindex). Users can now navigate, expand, and collapse tree nodes using arrow keys or the tab key. The "End" and "Home" keys move focus to the top and bottom page in the current nesting level. The "Enter" key opens the edit form for the page, and (when "batch actions" mode has been activated) the space bar selects the page.
 
 ### Keyboard navigation for "Files" admin section
 


### PR DESCRIPTION
That was the behaviour in an earlier implementation, before we found the W3C examples to follow.

## Issue

- https://github.com/silverstripe/developer-docs/issues/887